### PR TITLE
Add pytest Summary to Job Step Summary

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,8 @@ jobs:
           filename: coverage.xml
           format: markdown
           output: file
+          hide_branch_rate: true
+          hide_complexity: true
           thresholds: '50 90'
       - run: |
           echo '### Pytest Coverage Summary' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- generate coverage XML from pytest
- convert coverage report to Markdown using `irongut/CodeCoverageSummary` and append to GitHub Actions step summary

## Testing
- `uv run --group test pytest .`
- `uvx pre-commit run -a`


------
https://chatgpt.com/codex/tasks/task_e_688f5c3118ec832da1714735e7f41894