### PR TITLE
Add dataclass serializer using Annotated metadata

### DIFF
--- a/src/pybag/encoding/__init__.py
+++ b/src/pybag/encoding/__init__.py
@@ -1,0 +1,6 @@
+"""Encoding utilities."""
+
+from .cdr import CdrDecoder, CdrEncoder
+from .serializer import serialize
+
+__all__ = ["CdrDecoder", "CdrEncoder", "serialize"]

--- a/src/pybag/encoding/serializer.py
+++ b/src/pybag/encoding/serializer.py
@@ -1,0 +1,70 @@
+"""Utilities for serializing dataclasses into CDR byte streams."""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from typing import Any, Annotated, get_args, get_origin, Tuple
+
+from .cdr import CdrEncoder
+
+
+def _parse_annotation(annotation: Any, field_name: str) -> Tuple[str, Tuple[Any, ...]]:
+    """Extract encoder method and arguments from an annotation.
+
+    The annotation must be ``typing.Annotated`` where the first metadata item
+    specifies the :class:`CdrEncoder` method name.  Additional metadata items are
+    interpreted as positional arguments to that method (excluding the value to be
+    encoded which is appended automatically).
+    """
+
+    if get_origin(annotation) is not Annotated:
+        raise TypeError(
+            f"Field '{field_name}' must be typing.Annotated with CDR metadata."
+        )
+
+    args = get_args(annotation)
+    if len(args) < 2:
+        raise TypeError(
+            f"Field '{field_name}' missing CDR metadata in its Annotated alias."
+        )
+
+    metadata = args[1]
+    if isinstance(metadata, str):
+        return metadata, ()
+    if isinstance(metadata, tuple) and metadata and isinstance(metadata[0], str):
+        return metadata[0], tuple(metadata[1:])
+
+    raise TypeError(
+        f"Field '{field_name}' has unsupported CDR annotation metadata: {metadata!r}"
+    )
+
+
+def serialize(obj: Any, *, little_endian: bool = True) -> bytes:
+    """Serialize a dataclass instance into a CDR byte stream.
+
+    Args:
+        obj: The dataclass instance to serialize.
+        little_endian: Whether the resulting CDR stream should be little endian.
+
+    Returns:
+        The serialized CDR byte stream.
+    """
+
+    if not is_dataclass(obj):
+        raise TypeError("serialize() expects a dataclass instance")
+
+    encoder = CdrEncoder(little_endian=little_endian)
+
+    for name, annotation in obj.__annotations__.items():
+        method_name, method_args = _parse_annotation(annotation, name)
+        try:
+            method = getattr(encoder, method_name)
+        except AttributeError as exc:
+            raise ValueError(
+                f"Unsupported CDR type '{method_name}' for field '{name}'"
+            ) from exc
+
+        value = getattr(obj, name)
+        method(*method_args, value)
+
+    return encoder.save()

--- a/tests/encoding/test_serializer.py
+++ b/tests/encoding/test_serializer.py
@@ -1,0 +1,56 @@
+import pytest
+from dataclasses import dataclass
+from typing import Annotated, List
+
+from pybag.encoding.cdr import CdrDecoder
+from pybag.encoding.serializer import serialize
+
+
+@dataclass
+class Example:
+    integer: Annotated[int, "int32"]
+    name: Annotated[str, "string"]
+    flag: Annotated[bool, "bool"]
+
+
+def test_serialize_dataclass_primitives() -> None:
+    obj = Example(42, "hi", True)
+    data = serialize(obj)
+
+    decoder = CdrDecoder(data)
+    assert decoder.int32() == 42
+    assert decoder.string() == "hi"
+    assert decoder.bool() is True
+
+
+@dataclass
+class SeqExample:
+    numbers: Annotated[List[int], ("sequence", "int32")]
+
+
+def test_serialize_sequence() -> None:
+    obj = SeqExample([1, 2, 3])
+    data = serialize(obj)
+
+    decoder = CdrDecoder(data)
+    assert decoder.sequence("int32") == [1, 2, 3]
+
+
+@dataclass
+class Missing:
+    value: int
+
+
+def test_missing_annotation_error() -> None:
+    with pytest.raises(TypeError):
+        serialize(Missing(1))
+
+
+@dataclass
+class Unsupported:
+    value: Annotated[int, "unknown"]
+
+
+def test_unsupported_annotation_error() -> None:
+    with pytest.raises(ValueError):
+        serialize(Unsupported(1))


### PR DESCRIPTION
## Summary
- add CDR serializer that inspects dataclass annotations and uses `Annotated` metadata to map fields to `CdrEncoder` methods
- expose serializer in encoding package
- test dataclass serialization, sequences, and error handling

## Testing
- `uvx pre-commit run -a`
- `uv run --group test pytest .`


------
https://chatgpt.com/codex/tasks/task_e_6897ce95b114832d9bbd919e3dae97c1