### PR TITLE
feat: compile message schemas for faster decoding

### DIFF
--- a/src/pybag/encoding/__init__.py
+++ b/src/pybag/encoding/__init__.py
@@ -8,7 +8,7 @@ class MessageDecoder(ABC):
         ...
 
     @abstractmethod
-    def load(self) -> tuple[Any, ...]:
+    def load(self, *type_strs: str) -> tuple[Any, ...]:
         ...
 
     # Primitive parsers -------------------------------------------------

--- a/src/pybag/encoding/cdr.py
+++ b/src/pybag/encoding/cdr.py
@@ -55,7 +55,10 @@ class CdrDecoder(MessageDecoder):
         getattr(self, type_str)()
         return self
 
-    def load(self) -> tuple[Any, ...]:
+    def load(self, *type_strs: str) -> tuple[Any, ...]:
+        for type_str in type_strs:
+            self.push(type_str)
+
         if (size := struct.calcsize(self._loaded)) > 0:
             self._buffer += struct.unpack(self._loaded, self._data.read(size))
         data = self._buffer

--- a/src/pybag/schema/compiler.py
+++ b/src/pybag/schema/compiler.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from pybag.encoding import MessageDecoder
+from pybag.schema import (
+    Array,
+    Complex,
+    Primitive,
+    Schema,
+    SchemaConstant,
+    SchemaField,
+    Sequence,
+    String
+)
+
+
+class SchemaCompiler:
+    """Compile :class:`Schema` objects into efficient decoder functions."""
+
+    def __init__(self, sub_schemas: dict[str, Schema]):
+        self._sub_schemas = sub_schemas
+        self._namespace: dict[str, object] = {}
+        self._compiled: dict[str, Callable[[MessageDecoder], type]] = {}
+
+    def _func_name(self, schema_name: str) -> str:
+        return "decode_" + schema_name.replace("/", "_").replace(".", "_")
+
+    def compile(self, schema: Schema) -> Callable[[MessageDecoder], type]:
+        self._compile_schema(schema)
+        return self._compiled[schema.name]
+
+    # ------------------------------------------------------------------
+    def _compile_schema(self, schema: Schema) -> None:
+        if schema.name in self._compiled:
+            return
+
+        func_name = self._func_name(schema.name)
+        lines: list[str] = [f"def {func_name}(decoder):", "    field = {}"]
+
+        grouped: list[tuple[str, str]] = []
+
+        def flush() -> None:
+            if not grouped:
+                return
+            types = ", ".join([f"'{t}'" for _, t in grouped])
+            assigns = ", ".join([f"field['{n}']" for n, _ in grouped])
+            if len(grouped) == 1:
+                lines.append(f"    {assigns} = decoder.load({types})[0]")
+            else:
+                lines.append(f"    {assigns} = decoder.load({types})")
+            grouped.clear()
+
+        for field_name, field_schema in schema.fields.items():
+            if isinstance(field_schema, SchemaConstant):
+                flush()
+                lines.append(f"    field['{field_name}'] = {field_schema.value!r}")
+                continue
+
+            if not isinstance(field_schema, SchemaField):
+                raise ValueError(f'Unknown field type: {field_schema}')
+
+            field_type = field_schema.type
+
+            if isinstance(field_type, (Primitive, String)):
+                grouped.append((field_name, field_type.type))
+                continue
+
+            flush()
+
+            if isinstance(field_type, Array):
+                elem = field_type.type
+                if isinstance(elem, (Primitive, String)):
+                    lines.append(
+                        f"    field['{field_name}'] = decoder.array('{elem.type}', {field_type.length}).load()[0]"
+                    )
+                elif isinstance(elem, Complex):
+                    sub = self._sub_schemas[elem.type]
+                    self._compile_schema(sub)
+                    sub_name = self._func_name(elem.type)
+                    lines.append(
+                        f"    field['{field_name}'] = [{sub_name}(decoder) for _ in range({field_type.length})]"
+                    )
+                else:
+                    raise ValueError(f'Unknown array element type: {elem}')
+                continue
+
+            if isinstance(field_type, Sequence):
+                elem = field_type.type
+                if isinstance(elem, (Primitive, String)):
+                    lines.append(
+                        f"    field['{field_name}'] = decoder.sequence('{elem.type}').load()[0]"
+                    )
+                elif isinstance(elem, Complex):
+                    sub = self._sub_schemas[elem.type]
+                    self._compile_schema(sub)
+                    sub_name = self._func_name(elem.type)
+                    lines.append("    length = decoder.uint32().load()[0]")
+                    lines.append(
+                        f"    field['{field_name}'] = [{sub_name}(decoder) for _ in range(length)]"
+                    )
+                else:
+                    raise ValueError(f'Unknown sequence element type: {elem}')
+                continue
+
+            if isinstance(field_type, Complex):
+                sub = self._sub_schemas[field_type.type]
+                self._compile_schema(sub)
+                sub_name = self._func_name(field_type.type)
+                lines.append(f"    field['{field_name}'] = {sub_name}(decoder)")
+                continue
+
+            raise ValueError(f'Unknown field type: {field_type}')
+
+        flush()
+        lines.append(
+            f"    return type('{schema.name.replace('/', '.')}', (), field)"
+        )
+
+        src = "\n".join(lines)
+        exec(src, self._namespace)
+        self._compiled[schema.name] = self._namespace[func_name]
+
+
+def compile_decoder(schema: Schema, sub_schemas: dict[str, Schema]) -> Callable[[MessageDecoder], type]:
+    """Compile ``schema`` into a decoder function."""
+    compiler = SchemaCompiler(sub_schemas)
+    return compiler.compile(schema)


### PR DESCRIPTION
## Summary
- compile message schemas into Python decoder functions with batching of primitive fields
- cache compiled decoders in `MessageDeserializer` for reuse and faster decoding
- batch field types into `decoder.load` to minimize push calls

## Testing
- `uvx pre-commit run -a`
- `uv run --group test pytest .`


------
https://chatgpt.com/codex/tasks/task_e_68c5caf285e8832d926c0d1fecf885d8