### PR TITLE
Add ros1 benchmark coverage for rosbags and mcap

### DIFF
--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -2,7 +2,10 @@ import random
 from pathlib import Path
 
 import numpy as np
-from rosbags.rosbag2 import StoragePlugin, Writer
+from mcap.writer import Writer as McapWriter
+from rosbags.rosbag1 import Writer as Rosbag1Writer
+from rosbags.rosbag2 import StoragePlugin
+from rosbags.rosbag2 import Writer as Rosbag2Writer
 from rosbags.typesys import Stores, get_typestore
 
 
@@ -22,7 +25,7 @@ def create_test_mcap(path: Path, message_count: int = 1000, seed: int = 0) -> Pa
     Twist = typestore.types["geometry_msgs/msg/Twist"]
     Vector3 = typestore.types["geometry_msgs/msg/Vector3"]
 
-    with Writer(path, version=9, storage_plugin=StoragePlugin.MCAP) as writer:
+    with Rosbag2Writer(path, version=9, storage_plugin=StoragePlugin.MCAP) as writer:
         odom_conn = writer.add_connection("/odom", Odometry.__msgtype__, typestore=typestore)
         for i in range(message_count):
             timestamp = int(i * 1_500_000_000)
@@ -70,3 +73,123 @@ def create_test_mcap(path: Path, message_count: int = 1000, seed: int = 0) -> Pa
             writer.write(odom_conn, timestamp, typestore.serialize_cdr(odom, Odometry.__msgtype__))
 
     return next(Path(path).rglob("*.mcap"))
+
+
+def generate_ros1_odometries(message_count: int = 1000, seed: int = 0) -> list:
+    """Generate ROS 1 Odometry messages."""
+
+    rng = random.Random(seed)
+
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    Odometry = typestore.types["nav_msgs/msg/Odometry"]
+    Header = typestore.types["std_msgs/msg/Header"]
+    Time = typestore.types["builtin_interfaces/msg/Time"]
+    PoseWithCovariance = typestore.types["geometry_msgs/msg/PoseWithCovariance"]
+    Pose = typestore.types["geometry_msgs/msg/Pose"]
+    Point = typestore.types["geometry_msgs/msg/Point"]
+    Quaternion = typestore.types["geometry_msgs/msg/Quaternion"]
+    TwistWithCovariance = typestore.types["geometry_msgs/msg/TwistWithCovariance"]
+    Twist = typestore.types["geometry_msgs/msg/Twist"]
+    Vector3 = typestore.types["geometry_msgs/msg/Vector3"]
+
+    messages: list = []
+    for i in range(message_count):
+        timestamp = int(i * 1_500_000_000)
+        odom = Odometry(
+            header=Header(
+                seq=i,
+                stamp=Time(
+                    sec=timestamp // 1_000_000_000,
+                    nanosec=timestamp % 1_000_000_000,
+                ),
+                frame_id="map",
+            ),
+            child_frame_id="base_link",
+            pose=PoseWithCovariance(
+                pose=Pose(
+                    position=Point(
+                        x=rng.random(),
+                        y=rng.random(),
+                        z=rng.random(),
+                    ),
+                    orientation=Quaternion(
+                        x=rng.random(),
+                        y=rng.random(),
+                        z=rng.random(),
+                        w=rng.random(),
+                    ),
+                ),
+                covariance=np.array([rng.random() for _ in range(36)], dtype=np.float64),
+            ),
+            twist=TwistWithCovariance(
+                twist=Twist(
+                    linear=Vector3(
+                        x=rng.random(),
+                        y=rng.random(),
+                        z=rng.random(),
+                    ),
+                    angular=Vector3(
+                        x=rng.random(),
+                        y=rng.random(),
+                        z=rng.random(),
+                    ),
+                ),
+                covariance=np.array([rng.random() for _ in range(36)], dtype=np.float64),
+            ),
+        )
+        messages.append(odom)
+
+    return messages
+
+
+def create_test_ros1_bag(path: Path, message_count: int = 1000, seed: int = 0) -> Path:
+    """Create a ROS 1 rosbag with Odometry messages."""
+
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    msgtype = "nav_msgs/msg/Odometry"
+    bag_path = path.with_suffix(".bag")
+
+    with Rosbag1Writer(bag_path) as writer:
+        connection = writer.add_connection("/odom", msgtype, typestore=typestore)
+        for i, ros_msg in enumerate(generate_ros1_odometries(message_count, seed)):
+            timestamp = int(i * 1_500_000_000)
+            serialized_msg = typestore.serialize_ros1(ros_msg, msgtype)
+            writer.write(connection, timestamp, serialized_msg)
+
+    return bag_path
+
+
+def create_test_ros1_mcap(path: Path, message_count: int = 1000, seed: int = 0) -> Path:
+    """Create an MCAP file with ROS 1 Odometry messages."""
+
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    msgtype = "nav_msgs/msg/Odometry"
+    ros1_msgtype = msgtype.replace("/msg/", "/")
+    msgdef, _ = typestore.generate_msgdef(msgtype)
+    mcap_path = path.with_suffix(".mcap")
+
+    with open(mcap_path, "wb") as stream:
+        writer = McapWriter(stream)
+        writer.start(profile="ros1", library="pybag-benchmarks")
+        schema_id = writer.register_schema(
+            name=ros1_msgtype,
+            data=msgdef.encode(),
+            encoding="ros1msg",
+        )
+        channel_id = writer.register_channel(
+            topic="/odom",
+            schema_id=schema_id,
+            message_encoding="ros1",
+        )
+        for i, ros_msg in enumerate(generate_ros1_odometries(message_count, seed)):
+            timestamp = int(i * 1_500_000_000)
+            serialized_msg = typestore.serialize_ros1(ros_msg, msgtype)
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=timestamp,
+                publish_time=timestamp,
+                data=serialized_msg,
+            )
+        writer.finish()
+
+    return mcap_path

--- a/benchmarks/test_ros1_reader_decoded.py
+++ b/benchmarks/test_ros1_reader_decoded.py
@@ -1,0 +1,40 @@
+from collections import deque
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Iterator
+
+from mcap.reader import make_reader
+from mcap_ros1.decoder import DecoderFactory
+from pytest_benchmark.fixture import BenchmarkFixture
+from rosbags.highlevel import AnyReader
+from rosbags.typesys import Stores, get_typestore
+
+from .benchmark_utils import create_test_ros1_bag, create_test_ros1_mcap
+
+
+def read_decoded_with_rosbags(bag: Path) -> Iterator[Any]:
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    with AnyReader([bag], default_typestore=typestore) as reader:
+        for connection, _timestamp, data in reader.messages():
+            yield reader.deserialize(data, connection.msgtype)
+
+
+def read_decoded_with_official(mcap: Path) -> Iterator[Any]:
+    with open(mcap, "rb") as stream:
+        reader = make_reader(stream, decoder_factories=[DecoderFactory()])
+        for _schema, _channel, _message, ros_msg in reader.iter_decoded_messages(
+            log_time_order=True,
+        ):
+            yield ros_msg
+
+
+def test_rosbags_read_decoded(benchmark: BenchmarkFixture) -> None:
+    with TemporaryDirectory() as tmpdir:
+        bag = create_test_ros1_bag(Path(tmpdir) / "ros1")
+        benchmark(lambda: deque(read_decoded_with_rosbags(bag), maxlen=0))
+
+
+def test_official_read_decoded(benchmark: BenchmarkFixture) -> None:
+    with TemporaryDirectory() as tmpdir:
+        mcap = create_test_ros1_mcap(Path(tmpdir) / "ros1")
+        benchmark(lambda: deque(read_decoded_with_official(mcap), maxlen=0))

--- a/benchmarks/test_ros1_reader_raw.py
+++ b/benchmarks/test_ros1_reader_raw.py
@@ -1,0 +1,35 @@
+from collections import deque
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterator
+
+from mcap.reader import make_reader
+from pytest_benchmark.fixture import BenchmarkFixture
+from rosbags.highlevel import AnyReader
+
+from .benchmark_utils import create_test_ros1_bag, create_test_ros1_mcap
+
+
+def read_raw_with_rosbags(bag: Path) -> Iterator[bytes]:
+    with AnyReader([bag]) as reader:
+        for _connection, _timestamp, data in reader.messages():
+            yield data
+
+
+def read_raw_with_official(mcap: Path) -> Iterator[bytes]:
+    with open(mcap, "rb") as stream:
+        reader = make_reader(stream)
+        for _schema, _channel, message in reader.iter_messages(log_time_order=True):
+            yield message.data
+
+
+def test_rosbags_read_raw(benchmark: BenchmarkFixture) -> None:
+    with TemporaryDirectory() as tmpdir:
+        bag = create_test_ros1_bag(Path(tmpdir) / "ros1")
+        benchmark(lambda: deque(read_raw_with_rosbags(bag), maxlen=0))
+
+
+def test_official_read_raw(benchmark: BenchmarkFixture) -> None:
+    with TemporaryDirectory() as tmpdir:
+        mcap = create_test_ros1_mcap(Path(tmpdir) / "ros1")
+        benchmark(lambda: deque(read_raw_with_official(mcap), maxlen=0))

--- a/benchmarks/test_ros1_writer.py
+++ b/benchmarks/test_ros1_writer.py
@@ -1,0 +1,76 @@
+from itertools import count
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterable
+
+from mcap.writer import Writer as McapWriter
+from pytest_benchmark.fixture import BenchmarkFixture
+from rosbags.rosbag1 import Writer as Rosbag1Writer
+from rosbags.typesys import Stores, get_typestore
+
+from .benchmark_utils import generate_ros1_odometries
+
+
+def test_rosbags_write(benchmark: BenchmarkFixture) -> None:
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    msgtype = "nav_msgs/msg/Odometry"
+
+    def _write_with_rosbags(path: Path, messages: Iterable) -> None:
+        with Rosbag1Writer(path) as writer:
+            connection = writer.add_connection("/odom", msgtype, typestore=typestore)
+            for i, ros_msg in enumerate(messages):
+                timestamp = int(i * 1_500_000_000)
+                serialized = typestore.serialize_ros1(ros_msg, msgtype)
+                writer.write(connection, timestamp, serialized)
+
+    messages = generate_ros1_odometries()
+    with TemporaryDirectory() as tmpdir:
+        counter = count()
+        benchmark(
+            lambda: _write_with_rosbags(
+                Path(tmpdir) / f"rosbags_{next(counter)}.bag",
+                messages,
+            )
+        )
+
+
+def test_official_write(benchmark: BenchmarkFixture) -> None:
+    typestore = get_typestore(Stores.ROS1_NOETIC)
+    msgtype = "nav_msgs/msg/Odometry"
+    ros1_msgtype = msgtype.replace("/msg/", "/")
+    msgdef, _ = typestore.generate_msgdef(msgtype)
+
+    def _write_with_official(path: Path, messages: Iterable) -> None:
+        with open(path, "wb") as stream:
+            writer = McapWriter(stream)
+            writer.start(profile="ros1", library="pybag-benchmarks")
+            schema_id = writer.register_schema(
+                name=ros1_msgtype,
+                data=msgdef.encode(),
+                encoding="ros1msg",
+            )
+            channel_id = writer.register_channel(
+                topic="/odom",
+                schema_id=schema_id,
+                message_encoding="ros1",
+            )
+            for i, ros_msg in enumerate(messages):
+                timestamp = int(i * 1_500_000_000)
+                serialized = typestore.serialize_ros1(ros_msg, msgtype)
+                writer.add_message(
+                    channel_id=channel_id,
+                    log_time=timestamp,
+                    publish_time=timestamp,
+                    data=serialized,
+                )
+            writer.finish()
+
+    messages = generate_ros1_odometries()
+    with TemporaryDirectory() as tmpdir:
+        counter = count()
+        benchmark(
+            lambda: _write_with_official(
+                Path(tmpdir) / f"official_{next(counter)}.mcap",
+                messages,
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "pytest-benchmark>=4.0.0",
     "mcap>=1.2.2",
     "mcap-ros2-support>=0.5.5",
+    "mcap-ros1-support>=0.5.5",
     "rosbags>=0.10.10",
     "numpy>=2.2.3",
 ]

--- a/tests/test_mcap_reader.py
+++ b/tests/test_mcap_reader.py
@@ -1,6 +1,6 @@
 """Tests for the MCAP reader."""
-import random
 import logging
+import random
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -205,6 +205,19 @@ wheels = [
 ]
 
 [[package]]
+name = "mcap-ros1-support"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcap" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/c84710c529d0c11a31c8172ba4fa76f1b1e61ea396badd6df40ca7f41b77/mcap_ros1_support-0.7.3.tar.gz", hash = "sha256:605e8801c5abb0348a93021d6e879afd8ee45be158a44accd92fc29deee5e83e", size = 46172, upload-time = "2024-10-10T16:52:29.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/97/6551560b7a328a3ea8862a16e49fac850d74130d8f6cefcdd2918023ff51/mcap_ros1_support-0.7.3-py3-none-any.whl", hash = "sha256:ead18eabe3e910d5741e6d53d8a80328ebd99518a89d9a11c856c85073be2638", size = 68284, upload-time = "2024-10-10T16:52:28.201Z" },
+]
+
+[[package]]
 name = "mcap-ros2-support"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -307,7 +320,7 @@ wheels = [
 
 [[package]]
 name = "pybag-sdk"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -321,6 +334,7 @@ zstd = [
 [package.dev-dependencies]
 test = [
     { name = "mcap" },
+    { name = "mcap-ros1-support" },
     { name = "mcap-ros2-support" },
     { name = "numpy" },
     { name = "pytest" },
@@ -339,6 +353,7 @@ provides-extras = ["zstd", "lz4"]
 [package.metadata.requires-dev]
 test = [
     { name = "mcap", specifier = ">=1.2.2" },
+    { name = "mcap-ros1-support", specifier = ">=0.5.5" },
     { name = "mcap-ros2-support", specifier = ">=0.5.5" },
     { name = "numpy", specifier = ">=2.2.3" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -408,6 +423,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- extend the benchmark utilities to generate ROS 1 odometry test data and to create matching rosbag1 and MCAP fixtures
- add raw, decoded, and writer benchmark cases that compare rosbags with the official mcap library for ROS 1 recordings
- include the mcap-ros1-support dependency required for the new benchmarks

## Testing
- `uv run --group test pytest .` *(fails: existing MCAP reader tests unrelated to this change)*
- `uvx pre-commit run -a`


------
https://chatgpt.com/codex/tasks/task_e_68d0eaccb594832db1472b4fab56cad3