### PR TITLE
Add MCAP structure CLI and improve chunk handling

### DIFF
--- a/src/pybag/cli/main.py
+++ b/src/pybag/cli/main.py
@@ -1,4 +1,7 @@
 import argparse
+from pathlib import Path
+
+from pybag.cli.structure import structure_command
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -11,7 +14,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command")
 
-    # In the future subcommands will be added here.
+    structure_parser = subparsers.add_parser(
+        "structure",
+        help="Display a visual representation of the records contained in an MCAP file.",
+    )
+    structure_parser.add_argument(
+        "mcap",
+        type=Path,
+        help="Path to the MCAP file to inspect.",
+    )
+    structure_parser.set_defaults(func=structure_command)
+
 
     parser.set_defaults(func=lambda args: parser.print_help())
     return parser

--- a/src/pybag/cli/structure.py
+++ b/src/pybag/cli/structure.py
@@ -1,0 +1,326 @@
+"""Utilities for rendering MCAP file structure for the CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from pybag.io.raw_reader import BaseReader, BytesReader, FileReader
+from pybag.mcap.error import McapUnknownCompressionError
+from pybag.mcap.record_parser import McapRecordParser
+from pybag.mcap.record_reader import decompress_chunk
+from pybag.mcap.records import (
+    AttachmentIndexRecord,
+    AttachmentRecord,
+    ChannelRecord,
+    ChunkIndexRecord,
+    ChunkRecord,
+    DataEndRecord,
+    FooterRecord,
+    HeaderRecord,
+    MessageIndexRecord,
+    MessageRecord,
+    MetadataIndexRecord,
+    MetadataRecord,
+    RecordType,
+    SchemaRecord,
+    StatisticsRecord,
+    SummaryOffsetRecord
+)
+
+
+def describe_mcap_structure(file_path: Path) -> str:
+    """Return a human readable description of the MCAP structure."""
+
+    reader = FileReader(file_path)
+    try:
+        formatter = _McapStructureFormatter()
+        return formatter.describe(reader)
+    finally:
+        reader.close()
+
+
+def structure_command(args: Any) -> None:
+    """Entry point for the ``pybag structure`` CLI command."""
+
+    file_path: Path = args.mcap
+    if not file_path.exists():
+        raise SystemExit(f"MCAP file not found: {file_path}")
+
+    print(describe_mcap_structure(file_path))
+
+
+class _McapStructureFormatter:
+    """Format MCAP records into an ASCII box representation."""
+
+    def __init__(self) -> None:
+        self._lines: list[str] = []
+        self._schemas: dict[int, SchemaRecord] = {}
+        self._channels: dict[int, ChannelRecord] = {}
+        self._initial_magic_consumed = False
+
+    def describe(self, reader: BaseReader) -> str:
+        version = McapRecordParser.parse_magic_bytes(reader)
+        self._initial_magic_consumed = True
+        self._append_box("MAGIC_BYTES", [f"version: {version}"], indent=0)
+
+        for record_type_value, record in McapRecordParser.parse_record(reader):
+            try:
+                record_type = RecordType(record_type_value)
+            except ValueError:
+                self._append_box(
+                    f"UNKNOWN_RECORD ({record_type_value})",
+                    [],
+                    indent=0,
+                )
+                continue
+
+            self._format_record(record_type, record, indent=0)
+
+        return "\n".join(self._lines)
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+
+    def _format_record(self, record_type: RecordType, record: Any, indent: int) -> None:
+        if record_type == RecordType.HEADER:
+            self._append_box(
+                "HEADER",
+                [
+                    f"profile: {record.profile}",
+                    f"library: {record.library}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.FOOTER:
+            footer: FooterRecord = record
+            self._append_box(
+                "FOOTER",
+                [
+                    f"summary_start: {footer.summary_start}",
+                    f"summary_offset_start: {footer.summary_offset_start}",
+                    f"summary_crc: {footer.summary_crc}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.SCHEMA:
+            schema: SchemaRecord | None = record
+            if schema is None:
+                return
+            self._schemas[schema.id] = schema
+            self._append_box(
+                f"SCHEMA (id={schema.id})",
+                [
+                    f"name: {schema.name}",
+                    f"encoding: {schema.encoding}",
+                    f"data_size: {len(schema.data)} bytes",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.CHANNEL:
+            channel: ChannelRecord = record
+            self._channels[channel.id] = channel
+            schema_label = self._schema_label(channel.schema_id)
+            self._append_box(
+                f"CHANNEL (id={channel.id})",
+                [
+                    f"topic: {channel.topic}",
+                    f"schema: {schema_label}",
+                    f"message_encoding: {channel.message_encoding}",
+                    f"metadata: {len(channel.metadata)} entries",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.MESSAGE:
+            message: MessageRecord = record
+            channel_label = self._channel_label(message.channel_id)
+            schema_label = self._schema_for_channel(message.channel_id)
+            self._append_box(
+                f"MESSAGE (channel={message.channel_id})",
+                [
+                    f"channel: {channel_label}",
+                    f"sequence: {message.sequence}",
+                    f"schema: {schema_label}",
+                    f"log_time: {message.log_time}",
+                    f"publish_time: {message.publish_time}",
+                    f"size: {len(message.data)} bytes",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.CHUNK:
+            chunk: ChunkRecord = record
+            compression = chunk.compression or "none"
+            self._append_box(
+                "CHUNK",
+                [
+                    f"message_start: {chunk.message_start_time}",
+                    f"message_end: {chunk.message_end_time}",
+                    f"compression: {compression}",
+                    f"uncompressed_size: {chunk.uncompressed_size} bytes",
+                    f"uncompressed_crc: {chunk.uncompressed_crc}",
+                    f"records_length: {len(chunk.records)} bytes",
+                ],
+                indent,
+            )
+
+            try:
+                chunk_data = decompress_chunk(chunk)
+            except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - defensive
+                raise RuntimeError(
+                    "Unable to decompress chunk. Optional compression dependency missing."
+                ) from exc
+            except McapUnknownCompressionError as exc:  # pragma: no cover - defensive
+                raise RuntimeError(str(exc)) from exc
+
+            chunk_reader = BytesReader(chunk_data)
+            for inner_type_value, inner_record in McapRecordParser.parse_record(chunk_reader):
+                inner_type = RecordType(inner_type_value)
+                self._format_record(inner_type, inner_record, indent + 1)
+        elif record_type == RecordType.MESSAGE_INDEX:
+            message_index: MessageIndexRecord = record
+            channel_label = self._channel_label(message_index.channel_id)
+            entries = len(message_index.records)
+            body = [
+                f"channel: {channel_label}",
+                f"entries: {entries}",
+            ]
+            if entries:
+                start = message_index.records[0][0]
+                end = message_index.records[-1][0]
+                body.append(f"time_range: {start} -> {end}")
+            self._append_box("MESSAGE_INDEX", body, indent)
+        elif record_type == RecordType.CHUNK_INDEX:
+            chunk_index: ChunkIndexRecord = record
+            compression = chunk_index.compression or "none"
+            self._append_box(
+                "CHUNK_INDEX",
+                [
+                    f"message_start: {chunk_index.message_start_time}",
+                    f"message_end: {chunk_index.message_end_time}",
+                    f"chunk_start_offset: {chunk_index.chunk_start_offset}",
+                    f"chunk_length: {chunk_index.chunk_length}",
+                    f"message_index_length: {chunk_index.message_index_length}",
+                    f"message_index_offsets: {len(chunk_index.message_index_offsets)} entries",
+                    f"compression: {compression}",
+                    f"compressed_size: {chunk_index.compressed_size} bytes",
+                    f"uncompressed_size: {chunk_index.uncompressed_size} bytes",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.ATTACHMENT:
+            attachment: AttachmentRecord = record
+            self._append_box(
+                f"ATTACHMENT ({attachment.name})",
+                [
+                    f"log_time: {attachment.log_time}",
+                    f"create_time: {attachment.create_time}",
+                    f"media_type: {attachment.media_type}",
+                    f"size: {len(attachment.data)} bytes",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.METADATA:
+            metadata: MetadataRecord = record
+            self._append_box(
+                f"METADATA ({metadata.name})",
+                [f"entries: {len(metadata.metadata)}"],
+                indent,
+            )
+        elif record_type == RecordType.DATA_END:
+            data_end: DataEndRecord = record
+            self._append_box(
+                "DATA_END",
+                [f"data_section_crc: {data_end.data_section_crc}"],
+                indent,
+            )
+        elif record_type == RecordType.ATTACHMENT_INDEX:
+            attachment_index: AttachmentIndexRecord = record
+            self._append_box(
+                f"ATTACHMENT_INDEX ({attachment_index.name})",
+                [
+                    f"offset: {attachment_index.offset}",
+                    f"length: {attachment_index.length}",
+                    f"log_time: {attachment_index.log_time}",
+                    f"create_time: {attachment_index.create_time}",
+                    f"data_size: {attachment_index.data_size} bytes",
+                    f"media_type: {attachment_index.media_type}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.METADATA_INDEX:
+            metadata_index: MetadataIndexRecord = record
+            self._append_box(
+                f"METADATA_INDEX ({metadata_index.name})",
+                [
+                    f"offset: {metadata_index.offset}",
+                    f"length: {metadata_index.length}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.STATISTICS:
+            stats: StatisticsRecord = record
+            self._append_box(
+                "STATISTICS",
+                [
+                    f"message_count: {stats.message_count}",
+                    f"schema_count: {stats.schema_count}",
+                    f"channel_count: {stats.channel_count}",
+                    f"attachment_count: {stats.attachment_count}",
+                    f"metadata_count: {stats.metadata_count}",
+                    f"chunk_count: {stats.chunk_count}",
+                    f"message_start: {stats.message_start_time}",
+                    f"message_end: {stats.message_end_time}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.SUMMARY_OFFSET:
+            summary_offset: SummaryOffsetRecord = record
+            try:
+                group_name = RecordType(summary_offset.group_opcode).name
+            except ValueError:
+                group_name = str(summary_offset.group_opcode)
+            self._append_box(
+                "SUMMARY_OFFSET",
+                [
+                    f"group: {group_name}",
+                    f"group_start: {summary_offset.group_start}",
+                    f"group_length: {summary_offset.group_length}",
+                ],
+                indent,
+            )
+        elif record_type == RecordType.MAGIC_BYTES:
+            label = "MAGIC_BYTES (end)" if self._initial_magic_consumed else "MAGIC_BYTES"
+            self._append_box(label, [f"version: {record}"], indent)
+        else:  # pragma: no cover - defensive
+            self._append_box(record_type.name, [], indent)
+
+    def _append_box(self, title: str, body_lines: Iterable[str], indent: int) -> None:
+        body = list(body_lines)
+        width = max([len(title), *(len(line) for line in body)] or [len(title)])
+        padding = "    " * indent
+
+        top = f"{padding}┌{'─' * (width + 2)}┐"
+        header = f"{padding}│ {title.ljust(width)} │"
+        content = [f"{padding}│ {line.ljust(width)} │" for line in body]
+        bottom = f"{padding}└{'─' * (width + 2)}┘"
+
+        self._lines.extend([top, header, *content, bottom])
+
+    def _channel_label(self, channel_id: int) -> str:
+        channel = self._channels.get(channel_id)
+        if channel is None:
+            return str(channel_id)
+        return f"{channel_id} ({channel.topic})"
+
+    def _schema_label(self, schema_id: int) -> str:
+        schema = self._schemas.get(schema_id)
+        if schema is None:
+            return str(schema_id)
+        return f"{schema_id} ({schema.name})"
+
+    def _schema_for_channel(self, channel_id: int) -> str:
+        channel = self._channels.get(channel_id)
+        if channel is None:
+            return "unknown"
+        return self._schema_label(channel.schema_id)
+

--- a/src/pybag/mcap/record_reader.py
+++ b/src/pybag/mcap/record_reader.py
@@ -397,6 +397,10 @@ class McapRecordRandomAccessReader(BaseMcapRecordReader):
         if self._chunk_indexes is not None:
             return
 
+        if McapRecordType.CHUNK_INDEX not in self._summary_offset:
+            self._chunk_indexes = []
+            return
+
         self._file.seek_from_start(self._summary_offset[McapRecordType.CHUNK_INDEX].group_start)
         self._chunk_indexes = []
         while McapRecordParser.peek_record(self._file) == McapRecordType.CHUNK_INDEX:
@@ -494,8 +498,13 @@ class McapRecordRandomAccessReader(BaseMcapRecordReader):
         Returns:
             A generator of MessageRecord objects.
         """
-        for chunk_index in self.get_chunk_indexes(channel_id):
-            # Skip chunk that do not match the timestamp range
+        chunk_indexes = self.get_chunk_indexes(channel_id)
+        if not chunk_indexes:
+            yield from self._iterate_messages_without_chunks(channel_id, start_timestamp, end_timestamp)
+            return
+
+        entries: list[tuple[int, ChunkIndexRecord, int]] = []
+        for chunk_index in chunk_indexes:
             if start_timestamp is not None and chunk_index.message_end_time < start_timestamp:
                 continue
             if end_timestamp is not None and chunk_index.message_start_time > end_timestamp:
@@ -504,26 +513,93 @@ class McapRecordRandomAccessReader(BaseMcapRecordReader):
             if channel_id is None:
                 message_indexes = self.get_message_indexes(chunk_index).values()
             else:
-                message_indexes = [self.get_message_index(chunk_index, channel_id)]
-            if not message_indexes:
-                continue
+                message_index = self.get_message_index(chunk_index, channel_id)
+                message_indexes = [message_index] if message_index is not None else []
 
-            offsets: list[tuple[int, int]] = []
             for message_index in message_indexes:
                 for timestamp, offset in message_index.records:
                     if start_timestamp is not None and timestamp < start_timestamp:
                         continue
                     if end_timestamp is not None and timestamp > end_timestamp:
                         continue
-                    offsets.append((timestamp, offset))
-            if not offsets:
-                continue
+                    entries.append((timestamp, chunk_index, offset))
 
-            chunk = self.get_chunk(chunk_index)
-            reader = BytesReader(decompress_chunk(chunk, check_crc=self._check_crc))
-            for _timestamp, offset in offsets:
-                reader.seek_from_start(offset)
-                yield McapRecordParser.parse_message(reader)
+        entries.sort(key=lambda item: (item[0], item[1].chunk_start_offset, item[2]))
+
+        chunk_readers: dict[int, BytesReader] = {}
+        for _, chunk_index, offset in entries:
+            reader = chunk_readers.get(chunk_index.chunk_start_offset)
+            if reader is None:
+                chunk = self.get_chunk(chunk_index)
+                reader = BytesReader(decompress_chunk(chunk, check_crc=self._check_crc))
+                chunk_readers[chunk_index.chunk_start_offset] = reader
+            reader.seek_from_start(offset)
+            yield McapRecordParser.parse_message(reader)
+
+    def _iterate_messages_without_chunks(
+        self,
+        channel_id: int | None,
+        start_timestamp: int | None,
+        end_timestamp: int | None,
+    ) -> Generator[MessageRecord, None, None]:
+        position = self._file.tell()
+        messages: list[MessageRecord] = []
+        try:
+            self._file.seek_from_start(MAGIC_BYTES_SIZE)
+            while True:
+                record_type_value = McapRecordParser.peek_record(self._file)
+                if record_type_value == 0:
+                    break
+                record_type = McapRecordType(record_type_value)
+                if record_type == McapRecordType.DATA_END:
+                    McapRecordParser.parse_data_end(self._file)
+                    break
+                if record_type == McapRecordType.MESSAGE:
+                    message = McapRecordParser.parse_message(self._file)
+                    if channel_id is not None and message.channel_id != channel_id:
+                        continue
+                    if start_timestamp is not None and message.log_time < start_timestamp:
+                        continue
+                    if end_timestamp is not None and message.log_time > end_timestamp:
+                        continue
+                    messages.append(message)
+                    continue
+                if record_type == McapRecordType.CHUNK:
+                    chunk = McapRecordParser.parse_chunk(self._file)
+                    messages.extend(
+                        self._messages_from_chunk(chunk, channel_id, start_timestamp, end_timestamp)
+                    )
+                    continue
+                McapRecordParser.skip_record(self._file)
+        finally:
+            self._file.seek_from_start(position)
+
+        messages.sort(key=lambda msg: (msg.log_time, msg.publish_time, msg.sequence))
+        for message in messages:
+            yield message
+
+    def _messages_from_chunk(
+        self,
+        chunk: ChunkRecord,
+        channel_id: int | None,
+        start_timestamp: int | None,
+        end_timestamp: int | None,
+    ) -> list[MessageRecord]:
+        chunk_messages: list[MessageRecord] = []
+        chunk_reader = BytesReader(decompress_chunk(chunk, check_crc=self._check_crc))
+        for inner_type_value, inner_record in McapRecordParser.parse_record(chunk_reader):
+            inner_type = McapRecordType(inner_type_value)
+            if inner_type != McapRecordType.MESSAGE:
+                continue
+            message: MessageRecord = inner_record
+            if channel_id is not None and message.channel_id != channel_id:
+                continue
+            if start_timestamp is not None and message.log_time < start_timestamp:
+                continue
+            if end_timestamp is not None and message.log_time > end_timestamp:
+                continue
+            chunk_messages.append(message)
+        return chunk_messages
 
     # TODO: Low Priority
     # - Metadata Index

--- a/src/pybag/mcap_writer.py
+++ b/src/pybag/mcap_writer.py
@@ -181,6 +181,8 @@ class McapFileWriter:
         if self._chunk_size is not None:
             if self._current_chunk_start_time is None:
                 self._current_chunk_start_time = timestamp
+            else:
+                self._current_chunk_start_time = min(self._current_chunk_start_time, timestamp)
             self._current_chunk_end_time = max(self._current_chunk_end_time or timestamp, timestamp)
             offset = self._current_chunk_buffer.size()
             McapRecordWriter.write_message(self._current_chunk_buffer, record)
@@ -226,6 +228,7 @@ class McapFileWriter:
         message_index_offsets = {}
         message_index_start_offset = self._writer.tell()
         for cid, records in self._current_message_index.items():
+            records.sort(key=lambda item: (item[0], item[1]))
             message_index_offsets[cid] = self._writer.tell()
             message_index_record = MessageIndexRecord(channel_id=cid, records=records)
             McapRecordWriter.write_message_index(self._writer, message_index_record)

--- a/tests/test_cli_structure.py
+++ b/tests/test_cli_structure.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pybag.ros2.humble.std_msgs as std_msgs
+from pybag.cli.main import main
+from pybag.cli.structure import describe_mcap_structure
+from pybag.mcap_writer import McapFileWriter
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _write_simple_mcap(path: Path) -> None:
+    with McapFileWriter.open(path, profile="ros2") as writer:
+        writer.write_message("/example", 1, std_msgs.Int32(data=5))
+
+
+def _write_chunked_mcap(path: Path) -> None:
+    with McapFileWriter.open(
+        path,
+        profile="ros2",
+        chunk_size=1,
+        chunk_compression=None,
+    ) as writer:
+        writer.write_message("/example", 1, std_msgs.Int32(data=1))
+        writer.write_message("/example", 2, std_msgs.Int32(data=2))
+
+
+def test_describe_mcap_structure_lists_records(tmp_path: Path) -> None:
+    mcap_path = tmp_path / "simple.mcap"
+    _write_simple_mcap(mcap_path)
+
+    output = describe_mcap_structure(mcap_path)
+    lines = output.splitlines()
+
+    assert any("HEADER" in line for line in lines)
+    assert any("SCHEMA (id=" in line for line in lines)
+    assert any("CHANNEL (id=" in line for line in lines)
+    assert any("MESSAGE (channel=" in line for line in lines)
+    assert any("STATISTICS" in line for line in lines)
+    assert any("MAGIC_BYTES (end)" in line for line in lines)
+
+
+def test_describe_mcap_structure_shows_chunk_contents(tmp_path: Path) -> None:
+    mcap_path = tmp_path / "chunked.mcap"
+    _write_chunked_mcap(mcap_path)
+
+    output = describe_mcap_structure(mcap_path)
+    lines = output.splitlines()
+
+    assert any("CHUNK" in line for line in lines)
+    # Nested message box should be indented beneath the chunk.
+    assert any(line.startswith("    │ MESSAGE") for line in lines)
+    assert any("channel: 1 (/example)" in line for line in lines)
+
+
+def test_structure_command_prints_output(
+    tmp_path: Path, capsys: "pytest.CaptureFixture[str]"
+) -> None:
+    mcap_path = tmp_path / "cli.mcap"
+    _write_simple_mcap(mcap_path)
+
+    expected = describe_mcap_structure(mcap_path)
+
+    main(["structure", str(mcap_path)])
+    captured = capsys.readouterr()
+
+    assert captured.err == ""
+    assert captured.out.rstrip("\n") == expected
+

--- a/tests/test_mcap_reader.py
+++ b/tests/test_mcap_reader.py
@@ -1,6 +1,6 @@
 """Tests for the MCAP reader."""
-import random
 import logging
+import random
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "pybag-sdk"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- add a `pybag structure` CLI subcommand that renders MCAP record layouts as readable ASCII boxes
- support printing chunk contents and update tests to validate the command output
- fix MCAP chunk ordering by handling missing chunk indexes, sorting message lookups, and stabilising writer metadata

## Testing
- uv run --group test pytest .
- uvx pre-commit run -a

------
https://chatgpt.com/codex/tasks/task_e_68d19818ee1c832da44ed0db1b189cbb