### PR TITLE
Add HTTP streaming support for MCAP writer

### DIFF
--- a/src/pybag/mcap_writer.py
+++ b/src/pybag/mcap_writer.py
@@ -4,9 +4,16 @@ import logging
 import zlib
 from pathlib import Path
 from typing import Any, Callable, Literal
+from urllib.parse import urlparse
 
 from pybag import __version__
-from pybag.io.raw_writer import BaseWriter, BytesWriter, CrcWriter, FileWriter
+from pybag.io.raw_writer import (
+    BaseWriter,
+    BytesWriter,
+    CrcWriter,
+    FileWriter,
+    NetworkWriter
+)
 from pybag.mcap.record_writer import McapRecordWriter
 from pybag.mcap.records import (
     ChannelRecord,
@@ -101,8 +108,17 @@ class McapFileWriter:
             A writer backed by a file on disk.
         """
 
+        destination = str(file_path)
+        parsed = urlparse(destination)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            writer = NetworkWriter(destination)
+        elif parsed.scheme == "file" and parsed.path:
+            writer = FileWriter(Path(parsed.path))
+        else:
+            writer = FileWriter(file_path)
+
         return cls(
-            FileWriter(file_path),
+            writer,
             profile=profile,
             chunk_size=chunk_size,
             chunk_compression=chunk_compression,


### PR DESCRIPTION
## Summary
- add an HTTP-based NetworkWriter that streams MCAP records using chunked transfer
- update McapFileWriter.open to select the new network writer when a URL is provided
- exercise the streaming path with an integration-style test against a local HTTP server

## Testing
- uvx pre-commit run -a
- uv run --group test pytest -q tests/test_mcap_writer.py::test_streaming_writer_over_http

------
https://chatgpt.com/codex/tasks/task_e_68e04152b190832d8a28df2768f97e06