### PR TITLE
feat: Add event CLI for managing events in MCAP files

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,51 @@ pybag inspect channels recording.mcap --topic "/camera/*"
 pybag inspect metadata recording.mcap --name "calibration"
 pybag inspect attachments recording.mcap --name "calib.yaml" --data
 ```
+
+### event
+
+Manage events in MCAP files. Events are markers that indicate when something
+significant happens in the recording (e.g., collisions, waypoints, incidents).
+Events are stored as metadata records.
+
+**List events:**
+
+```bash
+pybag event list recording.mcap
+pybag event list recording.mcap --name "collision"
+pybag event list recording.mcap --json
+```
+
+**Add events (appends in place):**
+
+```bash
+pybag event add recording.mcap "collision" 10.5
+pybag event add recording.mcap "start" 0.0 --description "Recording started"
+pybag event add recording.mcap "waypoint" 25.0 --extra waypoint_id=42
+```
+
+**Delete events:**
+
+```bash
+pybag event delete recording.mcap -o cleaned.mcap
+pybag event delete recording.mcap --name "collision" -o cleaned.mcap
+pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 -o cleaned.mcap
+```
+
+**Clip around an event:**
+
+Extract a portion of the recording centered on an event's timestamp:
+
+```bash
+# Clip 5s before and 10s after the event
+pybag event clip recording.mcap "collision" --before 5 --after 10
+
+# Symmetric: 3s before AND after (only specify one)
+pybag event clip recording.mcap "incident" --before 3
+
+# Default: 5s before and after
+pybag event clip recording.mcap "start"
+
+# With topic filtering
+pybag event clip recording.mcap "crash" --include-topic "/camera/*" -o clip.mcap
+```

--- a/README.md
+++ b/README.md
@@ -292,26 +292,33 @@ pybag event list recording.mcap --json
 pybag event list recording.mcap --include-deleted  # show soft deleted events
 ```
 
-**Add events (appends in place):**
+**Add events:**
+
+By default, events are appended to the MCAP in place.
+Use `-o` to copy the MCAP and add the event to the copy instead.
 
 ```bash
+# Append in place (default)
 pybag event add recording.mcap "collision" 10.5
 pybag event add recording.mcap "start" 0.0 --description "Recording started"
 pybag event add recording.mcap "waypoint" 25.0 --extra waypoint_id=42
+
+# Copy mode: add event to a new copy
+pybag event add recording.mcap "collision" 10.5 -o with_event.mcap
 ```
 
 **Delete events:**
 
 By default, events are soft deleted (marked as deleted without rewriting the file).
-Use `--force` to perform a hard delete that rewrites the file.
+Use `-o` to copy the MCAP and hard delete (remove) the events from the copy.
 
 ```bash
 # Soft delete (default): marks events as deleted in place
 pybag event delete recording.mcap --name "collision"
 
-# Hard delete: rewrites the file without deleted events
-pybag event delete recording.mcap --name "collision" --force -o cleaned.mcap
-pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 --force -o cleaned.mcap
+# Hard delete: copies MCAP and removes events from the copy
+pybag event delete recording.mcap --name "collision" -o cleaned.mcap
+pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 -o cleaned.mcap
 ```
 
 **Clip around an event:**

--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ pybag inspect attachments recording.mcap --name "calib.yaml" --data
 
 ### event
 
-Manage events in MCAP files. Events are markers that indicate when something
+Manage events in MCAP files.
+
+Events are markers that indicate when something
 significant happens in the recording (e.g., collisions, waypoints, incidents).
 Events are stored as metadata records.
 
@@ -289,7 +291,6 @@ Events are stored as metadata records.
 pybag event list recording.mcap
 pybag event list recording.mcap --name "collision"
 pybag event list recording.mcap --json
-pybag event list recording.mcap --include-deleted  # show soft deleted events
 ```
 
 **Add events:**
@@ -309,14 +310,9 @@ pybag event add recording.mcap "collision" 10.5 -o with_event.mcap
 
 **Delete events:**
 
-By default, events are soft deleted (marked as deleted without rewriting the file).
 Use `-o` to copy the MCAP and hard delete (remove) the events from the copy.
 
 ```bash
-# Soft delete (default): marks events as deleted in place
-pybag event delete recording.mcap --name "collision"
-
-# Hard delete: copies MCAP and removes events from the copy
 pybag event delete recording.mcap --name "collision" -o cleaned.mcap
 pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 -o cleaned.mcap
 ```

--- a/README.md
+++ b/README.md
@@ -309,18 +309,21 @@ pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 -o cleaned.mc
 
 **Clip around an event:**
 
-Extract a portion of the recording centered on an event's timestamp:
+Extract a portion of the recording relative to an event's timestamp:
 
 ```bash
-# Clip 5s before and 10s after the event
-pybag event clip recording.mcap "collision" --before 5 --after 10
+# Symmetric: 5s before AND after the event
+pybag event clip recording.mcap "collision" --margin 5
 
-# Symmetric: 3s before AND after (only specify one)
-pybag event clip recording.mcap "incident" --before 3
+# Before only: from (event_time - 3s) to event_time
+pybag event clip recording.mcap "end" --before 3
 
-# Default: 5s before and after
-pybag event clip recording.mcap "start"
+# After only: from event_time to (event_time + 10s)
+pybag event clip recording.mcap "start" --after 10
+
+# Asymmetric: 5s before and 10s after
+pybag event clip recording.mcap "incident" --before 5 --after 10
 
 # With topic filtering
-pybag event clip recording.mcap "crash" --include-topic "/camera/*" -o clip.mcap
+pybag event clip recording.mcap "crash" --margin 5 --include-topic "/camera/*" -o clip.mcap
 ```

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Events are stored as metadata records.
 pybag event list recording.mcap
 pybag event list recording.mcap --name "collision"
 pybag event list recording.mcap --json
+pybag event list recording.mcap --include-deleted  # show soft deleted events
 ```
 
 **Add events (appends in place):**
@@ -301,10 +302,16 @@ pybag event add recording.mcap "waypoint" 25.0 --extra waypoint_id=42
 
 **Delete events:**
 
+By default, events are soft deleted (marked as deleted without rewriting the file).
+Use `--force` to perform a hard delete that rewrites the file.
+
 ```bash
-pybag event delete recording.mcap -o cleaned.mcap
-pybag event delete recording.mcap --name "collision" -o cleaned.mcap
-pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 -o cleaned.mcap
+# Soft delete (default): marks events as deleted in place
+pybag event delete recording.mcap --name "collision"
+
+# Hard delete: rewrites the file without deleted events
+pybag event delete recording.mcap --name "collision" --force -o cleaned.mcap
+pybag event delete recording.mcap --start-time 5.0 --end-time 10.0 --force -o cleaned.mcap
 ```
 
 **Clip around an event:**

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -444,6 +444,7 @@ def clip_event_mcap(
     output_path: str | Path | None = None,
     before: float | None = None,
     after: float | None = None,
+    margin: float | None = None,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -454,19 +455,19 @@ def clip_event_mcap(
     """Clip an MCAP file around an event.
 
     Extracts a portion of an MCAP file centered on an event's timestamp,
-    including a specified time margin before and after the event.
+    including a specified time margin before and/or after the event.
 
     Args:
         input_path: Path to input MCAP file.
         event_name: Name of the event to clip around.
         output_path: Path to output MCAP file. If None, defaults to
             <input_stem>_clip_<event_name>.mcap.
-        before: Time in seconds to include before the event. If None and after
-            is specified, uses the same value as after. If both are None,
-            defaults to 5.0 seconds.
-        after: Time in seconds to include after the event. If None and before
-            is specified, uses the same value as before. If both are None,
-            defaults to 5.0 seconds.
+        before: Time in seconds to include before the event. If specified
+            without --after, clips from (event_time - before) to event_time.
+        after: Time in seconds to include after the event. If specified
+            without --before, clips from event_time to (event_time + after).
+        margin: Symmetric margin - time in seconds to include both before
+            and after the event. Equivalent to --before X --after X.
         include_topics: List of topic patterns to include (glob patterns supported).
             If None, all topics are included.
         exclude_topics: List of topic patterns to exclude (glob patterns supported).
@@ -478,21 +479,29 @@ def clip_event_mcap(
         Path to the output MCAP file.
 
     Raises:
-        ValueError: If no event with the given name is found, or if multiple
-            events match and it's ambiguous which one to use.
+        ValueError: If no event with the given name is found, if conflicting
+            options are specified, or if no time range is specified.
     """
     from pybag.cli.filter import filter_mcap
 
     input_path = Path(input_path).resolve()
 
-    # Handle symmetric margins: if only one is given, use it for both
-    if before is None and after is None:
-        before = 5.0
-        after = 5.0
-    elif before is None:
-        before = after
-    elif after is None:
-        after = before
+    # Validate options
+    if margin is not None and (before is not None or after is not None):
+        raise ValueError("Cannot use --margin together with --before or --after")
+
+    # Determine time margins
+    if margin is not None:
+        before_margin = margin
+        after_margin = margin
+    elif before is None and after is None:
+        # Default to 5s margin if nothing specified
+        before_margin = 5.0
+        after_margin = 5.0
+    else:
+        # Use 0 for unspecified values (clip up to or from event time)
+        before_margin = before if before is not None else 0.0
+        after_margin = after if after is not None else 0.0
 
     # Find the event
     with McapRecordReaderFactory.from_file(input_path) as reader:
@@ -520,8 +529,8 @@ def clip_event_mcap(
     event_timestamp_s = _ns_to_seconds(event_timestamp_ns)
 
     # Calculate clip time range
-    start_time = event_timestamp_s - before
-    end_time = event_timestamp_s + after
+    start_time = event_timestamp_s - before_margin
+    end_time = event_timestamp_s + after_margin
 
     # Default output path
     if output_path is None:
@@ -548,6 +557,7 @@ def clip_event(
     output_path: str | Path | None = None,
     before: float | None = None,
     after: float | None = None,
+    margin: float | None = None,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -566,6 +576,7 @@ def clip_event(
             output_path=output_path,
             before=before,
             after=after,
+            margin=margin,
             include_topics=include_topics,
             exclude_topics=exclude_topics,
             chunk_size=chunk_size,
@@ -644,6 +655,7 @@ def _run_clip(args) -> None:
         output_path=args.output,
         before=args.before,
         after=args.after,
+        margin=args.margin,
         include_topics=args.include_topic,
         exclude_topics=args.exclude_topic,
         chunk_size=args.chunk_size,
@@ -796,17 +808,22 @@ def add_parser(subparsers) -> None:
         help="Extract a portion of an MCAP file around an event.",
         description=dedent("""
             Clip an MCAP file around an event, extracting messages within a time
-            window centered on the event's timestamp. This is useful for extracting
+            window relative to the event's timestamp. This is useful for extracting
             specific incidents or occurrences from a larger recording.
 
-            By default, if only --before or --after is specified, the other uses
-            the same value (symmetric clipping). If neither is specified, both
-            default to 5 seconds.
+            Time range options:
+              --margin X      Symmetric: X seconds before AND after the event
+              --before X      Clip from (event_time - X) to event_time
+              --after X       Clip from event_time to (event_time + X)
+              --before X --after Y  Clip from (event_time - X) to (event_time + Y)
+
+            If no time options are specified, defaults to --margin 5.
 
             Example:
-              pybag event clip recording.mcap "collision" --before 5 --after 10
+              pybag event clip recording.mcap "collision" --margin 5
               pybag event clip recording.mcap "start" --before 2
-              pybag event clip recording.mcap "incident" -o incident.mcap
+              pybag event clip recording.mcap "end" --after 10
+              pybag event clip recording.mcap "incident" --before 5 --after 10
         """),
     )
     clip_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
@@ -816,14 +833,19 @@ def add_parser(subparsers) -> None:
         help="Output file path. If not specified, creates <input>_clip_<event_name>.mcap",
     )
     clip_parser.add_argument(
+        "--margin",
+        type=float,
+        help="Symmetric margin: seconds to include before AND after the event",
+    )
+    clip_parser.add_argument(
         "--before",
         type=float,
-        help="Time in seconds to include before the event (default: 5.0, or same as --after)",
+        help="Seconds to include before the event (clips to event_time if --after not set)",
     )
     clip_parser.add_argument(
         "--after",
         type=float,
-        help="Time in seconds to include after the event (default: 5.0, or same as --before)",
+        help="Seconds to include after the event (clips from event_time if --before not set)",
     )
     clip_parser.add_argument(
         "--include-topic",

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -309,14 +309,41 @@ def add_event(
     input_path: str | Path,
     event_name: str,
     timestamp: float,
+    output_path: str | Path | None = None,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
 ) -> Path:
-    """Add an event to an MCAP file by appending in place."""
+    """Add an event to an MCAP file.
+
+    Args:
+        input_path: Path to the input MCAP file.
+        event_name: Name of the event.
+        timestamp: Event timestamp in seconds.
+        output_path: If provided, copy the MCAP and add event to the copy.
+            If None, append the event in place.
+        description: Optional event description.
+        extra_fields: Optional extra key-value pairs to include in the event.
+        chunk_size: Target chunk size for output (only used with output_path).
+        chunk_compression: Compression algorithm (only used with output_path).
+        overwrite: Whether to overwrite output file if it exists.
+
+    Returns:
+        Path to the file with the event added.
+    """
+    from pybag.cli.filter import filter_mcap
+
     input_path = Path(input_path).resolve()
     file_format = get_file_format_from_magic(input_path)
 
-    if file_format == "mcap":
+    if file_format != "mcap":
+        raise ValueError("Events are not supported in bag format.")
+
+    if output_path is None:
+        # Append in place
         return add_event_mcap(
             input_path,
             event_name,
@@ -325,7 +352,32 @@ def add_event(
             extra_fields=extra_fields,
         )
     else:
-        raise ValueError("Events are not supported in bag format.")
+        # Copy MCAP and add event to the copy
+        output_path = Path(output_path).resolve()
+
+        if output_path == input_path:
+            raise ValueError('Input path cannot be same as output.')
+
+        if not overwrite and output_path.exists():
+            raise ValueError('Output mcap exists. Please set `overwrite` to True.')
+
+        # First, copy the MCAP using filter (no filters = full copy)
+        filter_mcap(
+            input_path,
+            output_path=output_path,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            overwrite=overwrite,
+        )
+
+        # Then append the event to the copy
+        return add_event_mcap(
+            output_path,
+            event_name,
+            timestamp,
+            description=description,
+            extra_fields=extra_fields,
+        )
 
 
 #####################
@@ -742,6 +794,8 @@ def _run_list(args) -> None:
 
 def _run_add(args) -> None:
     """Run the event add command."""
+    from pybag.cli.utils import validate_compression_for_mcap
+
     # Parse extra key-value pairs
     extra_fields: dict[str, str] | None = None
     if args.extra:
@@ -752,12 +806,21 @@ def _run_add(args) -> None:
             key, value = item.split("=", 1)
             extra_fields[key] = value
 
+    output_path = getattr(args, 'output', None)
+    chunk_compression = validate_compression_for_mcap(
+        getattr(args, 'chunk_compression', None)
+    )
+
     file_path = add_event(
         args.input,
         args.name,
         args.timestamp,
+        output_path=output_path,
         description=args.description,
         extra_fields=extra_fields,
+        chunk_size=getattr(args, 'chunk_size', None),
+        chunk_compression=chunk_compression,
+        overwrite=getattr(args, 'overwrite', False),
     )
     print(f"Event added to: {file_path}")
 
@@ -766,10 +829,8 @@ def _run_delete(args) -> None:
     """Run the event delete command."""
     from pybag.cli.utils import validate_compression_for_mcap
 
-    force = getattr(args, 'force', False)
-
-    if force:
-        # Hard delete requires output path
+    if args.output:
+        # Hard delete: copy MCAP and remove events from the copy
         chunk_compression = validate_compression_for_mcap(args.chunk_compression)
         output_path, _ = delete_events(
             args.input,
@@ -784,7 +845,7 @@ def _run_delete(args) -> None:
         )
         print(f"Events deleted. Output written to: {output_path}")
     else:
-        # Soft delete modifies in place
+        # Soft delete: modify in place
         output_path, count = delete_events(
             args.input,
             name=args.name,
@@ -899,13 +960,16 @@ def add_parser(subparsers) -> None:
         "add",
         help="Add an event to an MCAP file.",
         description=dedent("""
-            Add a new event to an MCAP file. The event is appended directly to
-            the file without creating a copy. Events are markers with a timestamp
+            Add a new event to an MCAP file. Events are markers with a timestamp
             and name that indicate when something significant happened.
+
+            By default, the event is appended directly to the input file.
+            Use -o to copy the MCAP and add the event to the copy instead.
 
             Example:
               pybag event add recording.mcap "collision" 10.5 --description "Hit obstacle"
               pybag event add recording.mcap "start" 0.0
+              pybag event add recording.mcap "event" 5.0 -o output.mcap  # copy mode
         """),
     )
     add_parser_cmd.add_argument("input", help="Path to MCAP file (*.mcap)")
@@ -916,6 +980,10 @@ def add_parser(subparsers) -> None:
         help="Timestamp of the event in seconds",
     )
     add_parser_cmd.add_argument(
+        "-o", "--output",
+        help="Output file path. If specified, copies the MCAP and adds the event to the copy.",
+    )
+    add_parser_cmd.add_argument(
         "--description",
         help="Optional description of the event",
     )
@@ -924,6 +992,22 @@ def add_parser(subparsers) -> None:
         action="append",
         metavar="KEY=VALUE",
         help="Extra key-value pair to include in the event (can be used multiple times)",
+    )
+    add_parser_cmd.add_argument(
+        "--chunk-size",
+        type=int,
+        help="Chunk size of the output file in bytes (only used with -o)",
+    )
+    add_parser_cmd.add_argument(
+        "--chunk-compression",
+        type=str,
+        choices=["lz4", "zstd", "none"],
+        help="Compression used for chunk records (only used with -o)",
+    )
+    add_parser_cmd.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite output file if it exists (only used with -o)",
     )
     add_parser_cmd.set_defaults(func=_run_add)
 
@@ -940,18 +1024,18 @@ def add_parser(subparsers) -> None:
             deleted events are hidden from listing by default but can be shown
             with --include-deleted.
 
-            Use --force to perform a hard delete that rewrites the file without
-            the deleted events. This creates a new output file.
+            Use -o to copy the MCAP and hard delete (remove) the events from the
+            copy instead of soft deleting in place.
 
             Example:
               pybag event delete recording.mcap --name "collision"  # soft delete
-              pybag event delete recording.mcap --force -o clean.mcap  # hard delete
+              pybag event delete recording.mcap -o clean.mcap  # hard delete to copy
         """),
     )
     delete_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
     delete_parser.add_argument(
         "-o", "--output",
-        help="Output file path (only used with --force). Defaults to <input>_filtered.mcap",
+        help="Output file path. If specified, copies MCAP and removes events from copy.",
     )
     delete_parser.add_argument(
         "--name",
@@ -968,25 +1052,20 @@ def add_parser(subparsers) -> None:
         help="Delete events with timestamp <= end_time (in seconds)",
     )
     delete_parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Hard delete: rewrite the file without deleted events (creates new file)",
-    )
-    delete_parser.add_argument(
         "--chunk-size",
         type=int,
-        help="Chunk size of the output file in bytes (only used with --force)",
+        help="Chunk size of the output file in bytes (only used with -o)",
     )
     delete_parser.add_argument(
         "--chunk-compression",
         type=str,
         choices=["lz4", "zstd", "none"],
-        help="Compression used for chunk records (only used with --force)",
+        help="Compression used for chunk records (only used with -o)",
     )
     delete_parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Overwrite output file if it exists (only used with --force)",
+        help="Overwrite output file if it exists (only used with -o)",
     )
     delete_parser.set_defaults(func=_run_delete)
 

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -8,7 +8,6 @@ description and custom key-value pairs.
 import json
 import logging
 import shutil
-from collections import defaultdict
 from pathlib import Path
 from textwrap import dedent
 from tkinter.constants import FALSE
@@ -19,12 +18,12 @@ from pybag.cli.utils import (
     get_file_format_from_magic,
     validate_compression_for_mcap
 )
-from pybag.io.raw_reader import FileReader
 from pybag.io.raw_writer import FileWriter
 from pybag.mcap.record_reader import McapRecordReaderFactory
 from pybag.mcap.record_writer import McapRecordWriterFactory
-from pybag.mcap.records import MessageRecord, MetadataRecord
+from pybag.mcap.records import MetadataRecord
 from pybag.mcap.summary import McapSummaryFactory
+from pybag.mcap_writer import McapFileWriter
 
 logger = logging.getLogger(__name__)
 
@@ -239,31 +238,14 @@ def add_event_mcap(
     event_metadata: dict[str, str] = {
         "timestamp": str(timestamp_ns),
         "name": event_name,
+        "description": description or ""
     }
-    if description:
-        event_metadata["description"] = description
     if extra_fields:
         event_metadata.update(extra_fields)
 
-    # TODO: Replace this with the public writer append api
-    # Load existing summary from the file using FileReader (for peek support)
-    new_event = MetadataRecord(name=EVENT_METADATA_NAME, metadata=event_metadata)
-    summary = McapSummaryFactory.create_summary(
-        file=FileReader(input_path),
-        load_summary_eagerly=True,
-   )
-    # Open file for reading and writing (append mode)
-    file_writer = FileWriter(input_path, mode="r+b")
-    # Create writer in append mode - this will seek to before the data end record
-    # and set up the CRC writer with the existing CRC
-    with McapRecordWriterFactory.create_writer(
-        file_writer,
-        summary,
-        mode='a',
-        chunk_size=1024 * 1024,  # Default chunk size (not used for metadata)
-    ) as writer:
-        # Only write the new event metadata - all other records are preserved
-        writer.write_metadata(new_event)
+    # Write metadata record in append
+    with McapFileWriter.open(input_path, mode='a') as writer:
+        writer.write_metadata(EVENT_METADATA_NAME, event_metadata)
 
     return input_path
 
@@ -379,26 +361,9 @@ def delete_events_mcap(
     start_ns = _to_ns(start_time)
     end_ns = _to_ns(end_time)
 
-    # TODO: Simplify because we onlly need to delete relevant metadata records
     with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_schemas = reader.get_schemas()
         all_channels = reader.get_channels()
-        topic_to_channel_ids: dict[str, set[int]] = defaultdict(set)
-        for channel_id, channel in all_channels.items():
-            topic_to_channel_ids[channel.topic].add(channel_id)
-
-        all_attachments = reader.get_attachments()
-        all_metadata = reader.get_metadata()
-
-        # Count events to be deleted
-        events_to_delete = 0
-        for metadata in all_metadata:
-            if _is_event_metadata(metadata) and _event_matches_filters(
-                metadata, name, start_ns, end_ns
-            ):
-                events_to_delete += 1
-
-        if events_to_delete == 0:
-            logger.warning("No events match the deletion criteria.")
 
         with McapRecordWriterFactory.create_writer(
             FileWriter(output_path),
@@ -407,50 +372,35 @@ def delete_events_mcap(
             chunk_compression=chunk_compression,
             profile=reader.get_header().profile,
         ) as writer:
-            # Write message records
-            written_schema_ids: set[int] = set()
-            written_channel_ids: set[int] = set()
-            sequence_counters: dict[int, int] = defaultdict(int)
+            # Preserve all schema/channel definitions from the source file.
+            for schema_id in sorted(all_schemas):
+                writer.write_schema(all_schemas[schema_id])
 
+            for channel_id in sorted(all_channels):
+                writer.write_channel(all_channels[channel_id])
+
+            # Preserve message records as-is.
             for msg_record in reader.get_messages(in_log_time_order=False):
-                # Write the schema record the first time
-                schema_id = all_channels[msg_record.channel_id].schema_id
-                if schema_id != 0 and schema_id not in written_schema_ids:
-                    if (schema := reader.get_schema(schema_id)) is not None:
-                        writer.write_schema(schema)
-                        written_schema_ids.add(schema_id)
-
-                # Write the channel record the first time
-                if msg_record.channel_id not in written_channel_ids:
-                    writer.write_channel(all_channels[msg_record.channel_id])
-                    written_channel_ids.add(msg_record.channel_id)
-
-                # Write message with updated sequence number
-                new_record = MessageRecord(
-                    channel_id=msg_record.channel_id,
-                    sequence=sequence_counters[msg_record.channel_id],
-                    log_time=msg_record.log_time,
-                    publish_time=msg_record.publish_time,
-                    data=msg_record.data,
-                )
-                sequence_counters[msg_record.channel_id] += 1
-                writer.write_message(new_record)
+                writer.write_message(msg_record)
 
             # Write attachments
-            for attachment in all_attachments:
+            for attachment in reader.get_attachments():
                 writer.write_attachment(attachment)
 
-            # Write metadata, filtering out deleted events
+            # Write metadata, filtering out only matching event records.
             deleted_count = 0
-            for metadata in all_metadata:
-                if _is_event_metadata(metadata) and _event_matches_filters(
-                    metadata, name, start_ns, end_ns
-                ):
-                    # Skip this event (delete it)
-                    deleted_count += 1
-                    continue
+            for metadata in reader.get_metadata():
+                if metadata.name == EVENT_METADATA_NAME:
+                    if (
+                        _event_matches_name(metadata, name)
+                        and _event_matches_timestamp(metadata, start_ns, end_ns)
+                    ):
+                        deleted_count += 1
+                        continue
                 writer.write_metadata(metadata)
 
+            if deleted_count == 0:
+                logger.warning("No events match the deletion criteria.")
             logger.info(f"Deleted {deleted_count} event(s).")
 
     return output_path

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -1,0 +1,718 @@
+"""MCAP event CLI command for managing events in MCAP files.
+
+Events are stored as metadata records with a special name prefix to distinguish
+them from regular metadata. Each event has a timestamp, name, and optional
+description and custom key-value pairs.
+"""
+
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+from textwrap import dedent
+from typing import Literal
+
+from pybag.cli.utils import get_file_format_from_magic
+from pybag.io.raw_writer import FileWriter
+from pybag.mcap.record_reader import McapRecordReaderFactory
+from pybag.mcap.record_writer import McapRecordWriterFactory
+from pybag.mcap.records import MessageRecord, MetadataRecord
+from pybag.mcap.summary import McapSummaryFactory
+
+logger = logging.getLogger(__name__)
+
+# Event metadata record name - used to identify event records
+EVENT_METADATA_NAME = "pybag.event"
+
+
+def _ns_to_seconds(ns: int) -> float:
+    """Convert nanoseconds to seconds."""
+    return ns / 1_000_000_000
+
+
+def _to_ns(seconds: float | None) -> int | None:
+    """Convert seconds to nanoseconds."""
+    if seconds is None:
+        return None
+    return int(seconds * 1_000_000_000)
+
+
+def _is_event_metadata(metadata: MetadataRecord) -> bool:
+    """Check if a metadata record is an event."""
+    return metadata.name == EVENT_METADATA_NAME
+
+
+def _get_event_timestamp(metadata: MetadataRecord) -> int | None:
+    """Extract timestamp from event metadata."""
+    ts_str = metadata.metadata.get("timestamp")
+    if ts_str is None:
+        return None
+    try:
+        return int(ts_str)
+    except ValueError:
+        return None
+
+
+def _get_event_name(metadata: MetadataRecord) -> str:
+    """Extract event name from event metadata."""
+    return metadata.metadata.get("name", "")
+
+
+def _get_event_description(metadata: MetadataRecord) -> str | None:
+    """Extract event description from event metadata."""
+    return metadata.metadata.get("description")
+
+
+def _event_matches_filters(
+    metadata: MetadataRecord,
+    name: str | None = None,
+    start_time_ns: int | None = None,
+    end_time_ns: int | None = None,
+) -> bool:
+    """Check if an event matches the given filters."""
+    if name is not None:
+        event_name = _get_event_name(metadata)
+        if event_name != name:
+            return False
+
+    timestamp = _get_event_timestamp(metadata)
+    if timestamp is not None:
+        if start_time_ns is not None and timestamp < start_time_ns:
+            return False
+        if end_time_ns is not None and timestamp > end_time_ns:
+            return False
+
+    return True
+
+
+#####################
+# Event Listing     #
+#####################
+
+def _print_event_table(events: list[MetadataRecord]) -> None:
+    """Print events in a table format."""
+    if not events:
+        print("No events found.")
+        return
+
+    # Sort by timestamp
+    events = sorted(events, key=lambda e: _get_event_timestamp(e) or 0)
+
+    # Calculate column widths
+    max_name_len = max(len(_get_event_name(e)) for e in events) if events else 10
+    max_name_len = max(max_name_len, 4)  # Min width for "Name" header
+
+    # Print header
+    print(f"  {'Timestamp (s)':>16}  {'Name':<{max_name_len}}  Description")
+    print(f"  {'-' * 16}  {'-' * max_name_len}  {'-' * 40}")
+
+    # Print rows
+    for event in events:
+        timestamp = _get_event_timestamp(event)
+        timestamp_s = f"{_ns_to_seconds(timestamp):.6f}" if timestamp else "N/A"
+        name = _get_event_name(event)
+        description = _get_event_description(event) or ""
+        if len(description) > 50:
+            description = description[:47] + "..."
+        print(f"  {timestamp_s:>16}  {name:<{max_name_len}}  {description}")
+
+
+def _event_to_json(event: MetadataRecord) -> dict:
+    """Convert event metadata to JSON-serializable dict."""
+    timestamp = _get_event_timestamp(event)
+    result = {
+        "timestamp": timestamp,
+        "timestamp_seconds": _ns_to_seconds(timestamp) if timestamp else None,
+        "name": _get_event_name(event),
+    }
+    description = _get_event_description(event)
+    if description:
+        result["description"] = description
+
+    # Add any extra custom fields
+    for key, value in event.metadata.items():
+        if key not in ("timestamp", "name", "description"):
+            result[key] = value
+
+    return result
+
+
+def list_events_mcap(
+    input_path: Path,
+    *,
+    name: str | None = None,
+    start_time: float | None = None,
+    end_time: float | None = None,
+    output_json: bool = False,
+) -> None:
+    """List events in an MCAP file."""
+    start_ns = _to_ns(start_time)
+    end_ns = _to_ns(end_time)
+
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+
+        # Filter events
+        events = [
+            m for m in all_metadata
+            if _is_event_metadata(m) and _event_matches_filters(m, name, start_ns, end_ns)
+        ]
+
+        if output_json:
+            print(json.dumps([_event_to_json(e) for e in events], indent=2))
+        else:
+            print(f"Events ({len(events)}):\n")
+            _print_event_table(events)
+
+
+def list_events(
+    input_path: str | Path,
+    *,
+    name: str | None = None,
+    start_time: float | None = None,
+    end_time: float | None = None,
+    output_json: bool = False,
+) -> None:
+    """List events in an MCAP or bag file."""
+    input_path = Path(input_path).resolve()
+    file_format = get_file_format_from_magic(input_path)
+
+    if file_format == "mcap":
+        list_events_mcap(
+            input_path,
+            name=name,
+            start_time=start_time,
+            end_time=end_time,
+            output_json=output_json,
+        )
+    else:
+        print("Events are not supported in bag format.")
+
+
+#####################
+# Event Adding      #
+#####################
+
+def add_event_mcap(
+    input_path: str | Path,
+    event_name: str,
+    timestamp: float,
+    output_path: str | Path | None = None,
+    description: str | None = None,
+    extra_fields: dict[str, str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Add an event to an MCAP file.
+
+    Args:
+        input_path: Path to input MCAP file.
+        event_name: Name of the event.
+        timestamp: Event timestamp in seconds.
+        output_path: Path to output MCAP file. If None, defaults to
+            <input_stem>_with_event.mcap.
+        description: Optional event description.
+        extra_fields: Optional extra key-value pairs to include in the event.
+        chunk_size: Target chunk size in bytes for the output file.
+        chunk_compression: Compression algorithm for chunks.
+        overwrite: Whether to overwrite the output file if it exists.
+
+    Returns:
+        Path to the output MCAP file.
+
+    Raises:
+        ValueError: If input and output paths are the same, or if output exists
+            and overwrite is False.
+    """
+    input_path = Path(input_path).resolve()
+    if output_path is None:
+        output_path = input_path.with_name(f"{input_path.stem}_with_event.mcap")
+    output_path = Path(output_path).resolve()
+
+    if output_path == input_path:
+        raise ValueError('Input path cannot be same as output.')
+
+    if not overwrite and output_path.exists():
+        raise ValueError('Output mcap exists. Please set `overwrite` to True.')
+
+    timestamp_ns = _to_ns(timestamp)
+
+    # Build the event metadata
+    event_metadata: dict[str, str] = {
+        "timestamp": str(timestamp_ns),
+        "name": event_name,
+    }
+    if description:
+        event_metadata["description"] = description
+    if extra_fields:
+        event_metadata.update(extra_fields)
+
+    new_event = MetadataRecord(name=EVENT_METADATA_NAME, metadata=event_metadata)
+
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_channels = reader.get_channels()
+        topic_to_channel_ids: dict[str, set[int]] = defaultdict(set)
+        for channel_id, channel in all_channels.items():
+            topic_to_channel_ids[channel.topic].add(channel_id)
+
+        all_attachments = reader.get_attachments()
+        all_metadata = reader.get_metadata()
+
+        with McapRecordWriterFactory.create_writer(
+            FileWriter(output_path),
+            McapSummaryFactory.create_summary(chunk_size=chunk_size),
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            profile=reader.get_header().profile,
+        ) as writer:
+            # Write message records
+            written_schema_ids: set[int] = set()
+            written_channel_ids: set[int] = set()
+            sequence_counters: dict[int, int] = defaultdict(int)
+
+            for msg_record in reader.get_messages(in_log_time_order=False):
+                # Write the schema record the first time
+                schema_id = all_channels[msg_record.channel_id].schema_id
+                if schema_id != 0 and schema_id not in written_schema_ids:
+                    if (schema := reader.get_schema(schema_id)) is not None:
+                        writer.write_schema(schema)
+                        written_schema_ids.add(schema_id)
+
+                # Write the channel record the first time
+                if msg_record.channel_id not in written_channel_ids:
+                    writer.write_channel(all_channels[msg_record.channel_id])
+                    written_channel_ids.add(msg_record.channel_id)
+
+                # Write message with updated sequence number
+                new_record = MessageRecord(
+                    channel_id=msg_record.channel_id,
+                    sequence=sequence_counters[msg_record.channel_id],
+                    log_time=msg_record.log_time,
+                    publish_time=msg_record.publish_time,
+                    data=msg_record.data,
+                )
+                sequence_counters[msg_record.channel_id] += 1
+                writer.write_message(new_record)
+
+            # Write attachments
+            for attachment in all_attachments:
+                writer.write_attachment(attachment)
+
+            # Write existing metadata
+            for metadata in all_metadata:
+                writer.write_metadata(metadata)
+
+            # Write the new event
+            writer.write_metadata(new_event)
+
+    return output_path
+
+
+def add_event(
+    input_path: str | Path,
+    event_name: str,
+    timestamp: float,
+    output_path: str | Path | None = None,
+    description: str | None = None,
+    extra_fields: dict[str, str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Add an event to an MCAP or bag file."""
+    input_path = Path(input_path).resolve()
+    file_format = get_file_format_from_magic(input_path)
+
+    if file_format == "mcap":
+        return add_event_mcap(
+            input_path,
+            event_name,
+            timestamp,
+            output_path=output_path,
+            description=description,
+            extra_fields=extra_fields,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            overwrite=overwrite,
+        )
+    else:
+        raise ValueError("Events are not supported in bag format.")
+
+
+#####################
+# Event Deletion    #
+#####################
+
+def delete_events_mcap(
+    input_path: str | Path,
+    output_path: str | Path | None = None,
+    name: str | None = None,
+    start_time: float | None = None,
+    end_time: float | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Delete events from an MCAP file.
+
+    Args:
+        input_path: Path to input MCAP file.
+        output_path: Path to output MCAP file. If None, defaults to
+            <input_stem>_filtered.mcap.
+        name: Filter events to delete by name. If None, all events matching
+            other filters will be deleted.
+        start_time: Filter events to delete with timestamp >= start_time (seconds).
+        end_time: Filter events to delete with timestamp <= end_time (seconds).
+        chunk_size: Target chunk size in bytes for the output file.
+        chunk_compression: Compression algorithm for chunks.
+        overwrite: Whether to overwrite the output file if it exists.
+
+    Returns:
+        Path to the output MCAP file.
+
+    Raises:
+        ValueError: If input and output paths are the same, or if output exists
+            and overwrite is False.
+    """
+    input_path = Path(input_path).resolve()
+    if output_path is None:
+        output_path = input_path.with_name(f"{input_path.stem}_filtered.mcap")
+    output_path = Path(output_path).resolve()
+
+    if output_path == input_path:
+        raise ValueError('Input path cannot be same as output.')
+
+    if not overwrite and output_path.exists():
+        raise ValueError('Output mcap exists. Please set `overwrite` to True.')
+
+    start_ns = _to_ns(start_time)
+    end_ns = _to_ns(end_time)
+
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_channels = reader.get_channels()
+        topic_to_channel_ids: dict[str, set[int]] = defaultdict(set)
+        for channel_id, channel in all_channels.items():
+            topic_to_channel_ids[channel.topic].add(channel_id)
+
+        all_attachments = reader.get_attachments()
+        all_metadata = reader.get_metadata()
+
+        # Count events to be deleted
+        events_to_delete = 0
+        for metadata in all_metadata:
+            if _is_event_metadata(metadata) and _event_matches_filters(
+                metadata, name, start_ns, end_ns
+            ):
+                events_to_delete += 1
+
+        if events_to_delete == 0:
+            logger.warning("No events match the deletion criteria.")
+
+        with McapRecordWriterFactory.create_writer(
+            FileWriter(output_path),
+            McapSummaryFactory.create_summary(chunk_size=chunk_size),
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            profile=reader.get_header().profile,
+        ) as writer:
+            # Write message records
+            written_schema_ids: set[int] = set()
+            written_channel_ids: set[int] = set()
+            sequence_counters: dict[int, int] = defaultdict(int)
+
+            for msg_record in reader.get_messages(in_log_time_order=False):
+                # Write the schema record the first time
+                schema_id = all_channels[msg_record.channel_id].schema_id
+                if schema_id != 0 and schema_id not in written_schema_ids:
+                    if (schema := reader.get_schema(schema_id)) is not None:
+                        writer.write_schema(schema)
+                        written_schema_ids.add(schema_id)
+
+                # Write the channel record the first time
+                if msg_record.channel_id not in written_channel_ids:
+                    writer.write_channel(all_channels[msg_record.channel_id])
+                    written_channel_ids.add(msg_record.channel_id)
+
+                # Write message with updated sequence number
+                new_record = MessageRecord(
+                    channel_id=msg_record.channel_id,
+                    sequence=sequence_counters[msg_record.channel_id],
+                    log_time=msg_record.log_time,
+                    publish_time=msg_record.publish_time,
+                    data=msg_record.data,
+                )
+                sequence_counters[msg_record.channel_id] += 1
+                writer.write_message(new_record)
+
+            # Write attachments
+            for attachment in all_attachments:
+                writer.write_attachment(attachment)
+
+            # Write metadata, filtering out deleted events
+            deleted_count = 0
+            for metadata in all_metadata:
+                if _is_event_metadata(metadata) and _event_matches_filters(
+                    metadata, name, start_ns, end_ns
+                ):
+                    # Skip this event (delete it)
+                    deleted_count += 1
+                    continue
+                writer.write_metadata(metadata)
+
+            logger.info(f"Deleted {deleted_count} event(s).")
+
+    return output_path
+
+
+def delete_events(
+    input_path: str | Path,
+    output_path: str | Path | None = None,
+    name: str | None = None,
+    start_time: float | None = None,
+    end_time: float | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Delete events from an MCAP or bag file."""
+    input_path = Path(input_path).resolve()
+    file_format = get_file_format_from_magic(input_path)
+
+    if file_format == "mcap":
+        return delete_events_mcap(
+            input_path,
+            output_path=output_path,
+            name=name,
+            start_time=start_time,
+            end_time=end_time,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            overwrite=overwrite,
+        )
+    else:
+        raise ValueError("Events are not supported in bag format.")
+
+
+#####################
+# CLI Parser Setup  #
+#####################
+
+def _run_list(args) -> None:
+    """Run the event list command."""
+    list_events(
+        args.input,
+        name=args.name,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        output_json=args.output_json,
+    )
+
+
+def _run_add(args) -> None:
+    """Run the event add command."""
+    from pybag.cli.utils import validate_compression_for_mcap
+
+    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
+
+    # Parse extra key-value pairs
+    extra_fields: dict[str, str] | None = None
+    if args.extra:
+        extra_fields = {}
+        for item in args.extra:
+            if "=" not in item:
+                raise ValueError(f"Invalid extra field format: {item}. Expected 'key=value'")
+            key, value = item.split("=", 1)
+            extra_fields[key] = value
+
+    output_path = add_event(
+        args.input,
+        args.name,
+        args.timestamp,
+        output_path=args.output,
+        description=args.description,
+        extra_fields=extra_fields,
+        chunk_size=args.chunk_size,
+        chunk_compression=chunk_compression,
+        overwrite=args.overwrite,
+    )
+    print(f"Event added. Output written to: {output_path}")
+
+
+def _run_delete(args) -> None:
+    """Run the event delete command."""
+    from pybag.cli.utils import validate_compression_for_mcap
+
+    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
+
+    output_path = delete_events(
+        args.input,
+        output_path=args.output,
+        name=args.name,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        chunk_size=args.chunk_size,
+        chunk_compression=chunk_compression,
+        overwrite=args.overwrite,
+    )
+    print(f"Events deleted. Output written to: {output_path}")
+
+
+def add_parser(subparsers) -> None:
+    """Add the event command and its subcommands to the argument parser."""
+    event_parser = subparsers.add_parser(
+        "event",
+        help="Manage events in MCAP files.",
+        description=dedent("""
+            Manage events in MCAP files. Events are markers that indicate when
+            something happens in the recording, such as the start of a maneuver,
+            a collision, or any other significant occurrence.
+
+            Events are stored as metadata records with a special name. Each event
+            has a timestamp, a name, and an optional description.
+
+            Subcommands:
+              pybag event list <file>                - List all events
+              pybag event add <file> <name> <time>   - Add a new event
+              pybag event delete <file>              - Delete events
+
+            Note: Events are only supported in MCAP format, not bag files.
+        """),
+    )
+    event_subparsers = event_parser.add_subparsers(dest="event_command")
+    event_parser.set_defaults(func=lambda args: event_parser.print_help())
+
+    # List subcommand
+    list_parser = event_subparsers.add_parser(
+        "list",
+        help="List events in an MCAP file.",
+        description="List all events in an MCAP file. Use filters to narrow down the results.",
+    )
+    list_parser.add_argument("input", help="Path to MCAP file (*.mcap)")
+    list_parser.add_argument(
+        "--name",
+        help="Filter events by name",
+    )
+    list_parser.add_argument(
+        "--start-time",
+        type=float,
+        help="Filter events with timestamp >= start_time (in seconds)",
+    )
+    list_parser.add_argument(
+        "--end-time",
+        type=float,
+        help="Filter events with timestamp <= end_time (in seconds)",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output in JSON format",
+    )
+    list_parser.set_defaults(func=_run_list)
+
+    # Add subcommand
+    add_parser_cmd = event_subparsers.add_parser(
+        "add",
+        help="Add an event to an MCAP file.",
+        description=dedent("""
+            Add a new event to an MCAP file. Events are markers with a timestamp
+            and name that indicate when something significant happened.
+
+            Example:
+              pybag event add recording.mcap "collision" 10.5 --description "Hit obstacle"
+              pybag event add recording.mcap "start" 0.0 -o output.mcap
+        """),
+    )
+    add_parser_cmd.add_argument("input", help="Path to input MCAP file (*.mcap)")
+    add_parser_cmd.add_argument("name", help="Name of the event (e.g., 'start', 'collision')")
+    add_parser_cmd.add_argument(
+        "timestamp",
+        type=float,
+        help="Timestamp of the event in seconds",
+    )
+    add_parser_cmd.add_argument(
+        "-o", "--output",
+        help="Output file path. If not specified, creates <input>_with_event.mcap",
+    )
+    add_parser_cmd.add_argument(
+        "--description",
+        help="Optional description of the event",
+    )
+    add_parser_cmd.add_argument(
+        "--extra",
+        action="append",
+        metavar="KEY=VALUE",
+        help="Extra key-value pair to include in the event (can be used multiple times)",
+    )
+    add_parser_cmd.add_argument(
+        "--chunk-size",
+        type=int,
+        help="Chunk size of the output file in bytes",
+    )
+    add_parser_cmd.add_argument(
+        "--chunk-compression",
+        type=str,
+        choices=["lz4", "zstd", "none"],
+        help="Compression used for chunk records",
+    )
+    add_parser_cmd.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite output file if it exists",
+    )
+    add_parser_cmd.set_defaults(func=_run_add)
+
+    # Delete subcommand
+    delete_parser = event_subparsers.add_parser(
+        "delete",
+        help="Delete events from an MCAP file.",
+        description=dedent("""
+            Delete events from an MCAP file. Use filters to select which events
+            to delete. If no filters are provided, all events will be deleted.
+
+            Example:
+              pybag event delete recording.mcap --name "collision"
+              pybag event delete recording.mcap --start-time 5.0 --end-time 10.0
+        """),
+    )
+    delete_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
+    delete_parser.add_argument(
+        "-o", "--output",
+        help="Output file path. If not specified, creates <input>_filtered.mcap",
+    )
+    delete_parser.add_argument(
+        "--name",
+        help="Delete only events with this name",
+    )
+    delete_parser.add_argument(
+        "--start-time",
+        type=float,
+        help="Delete events with timestamp >= start_time (in seconds)",
+    )
+    delete_parser.add_argument(
+        "--end-time",
+        type=float,
+        help="Delete events with timestamp <= end_time (in seconds)",
+    )
+    delete_parser.add_argument(
+        "--chunk-size",
+        type=int,
+        help="Chunk size of the output file in bytes",
+    )
+    delete_parser.add_argument(
+        "--chunk-compression",
+        type=str,
+        choices=["lz4", "zstd", "none"],
+        help="Compression used for chunk records",
+    )
+    delete_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite output file if it exists",
+    )
+    delete_parser.set_defaults(func=_run_delete)

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -7,12 +7,18 @@ description and custom key-value pairs.
 
 import json
 import logging
+import shutil
 from collections import defaultdict
 from pathlib import Path
 from textwrap import dedent
+from tkinter.constants import FALSE
 from typing import Literal
 
-from pybag.cli.utils import get_file_format_from_magic
+from pybag.cli.filter import filter_mcap
+from pybag.cli.utils import (
+    get_file_format_from_magic,
+    validate_compression_for_mcap
+)
 from pybag.io.raw_reader import FileReader
 from pybag.io.raw_writer import FileWriter
 from pybag.mcap.record_reader import McapRecordReaderFactory
@@ -28,6 +34,17 @@ EVENT_METADATA_NAME = "pybag.event"
 
 def _ns_to_seconds(ns: int) -> float:
     """Convert nanoseconds to seconds."""
+    return ns / 1_000_000_000
+
+
+def _seconds_to_ns(seconds: float) -> int:
+    """Convert seconds to nanoseconds."""
+    return int(seconds * 1_000_000_000)
+
+
+def _to_s(ns: int | None) -> float | None:
+    if ns is None:
+        return None
     return ns / 1_000_000_000
 
 
@@ -59,40 +76,30 @@ def _get_event_name(metadata: MetadataRecord) -> str:
     return metadata.metadata.get("name", "")
 
 
-def _get_event_description(metadata: MetadataRecord) -> str | None:
+def _get_event_description(metadata: MetadataRecord) -> str:
     """Extract event description from event metadata."""
-    return metadata.metadata.get("description")
+    return metadata.metadata.get("description", "")
 
 
-def _is_event_deleted(metadata: MetadataRecord) -> bool:
-    """Check if an event is marked as deleted."""
-    return metadata.metadata.get("deleted", "").lower() == "true"
+def _event_matches_name(metadata: MetadataRecord, name: str | None) -> bool:
+    event_name = _get_event_name(metadata)
+    if name is not None:
+        return event_name == name
+    return True
 
 
-def _event_matches_filters(
+def _event_matches_timestamp(
     metadata: MetadataRecord,
-    name: str | None = None,
     start_time_ns: int | None = None,
     end_time_ns: int | None = None,
-    include_deleted: bool = False,
 ) -> bool:
     """Check if an event matches the given filters."""
-    # Filter out deleted events unless explicitly included
-    if not include_deleted and _is_event_deleted(metadata):
-        return False
-
-    if name is not None:
-        event_name = _get_event_name(metadata)
-        if event_name != name:
-            return False
-
     timestamp = _get_event_timestamp(metadata)
     if timestamp is not None:
         if start_time_ns is not None and timestamp < start_time_ns:
             return False
         if end_time_ns is not None and timestamp > end_time_ns:
             return False
-
     return True
 
 
@@ -122,7 +129,7 @@ def _print_event_table(events: list[MetadataRecord]) -> None:
         timestamp = _get_event_timestamp(event)
         timestamp_s = f"{_ns_to_seconds(timestamp):.6f}" if timestamp else "N/A"
         name = _get_event_name(event)
-        description = _get_event_description(event) or ""
+        description = _get_event_description(event)
         if len(description) > 50:
             description = description[:47] + "..."
         print(f"  {timestamp_s:>16}  {name:<{max_name_len}}  {description}")
@@ -130,46 +137,18 @@ def _print_event_table(events: list[MetadataRecord]) -> None:
 
 def _event_to_json(event: MetadataRecord) -> dict:
     """Convert event metadata to JSON-serializable dict."""
-    timestamp = _get_event_timestamp(event)
     result = {
-        "timestamp": timestamp,
-        "timestamp_seconds": _ns_to_seconds(timestamp) if timestamp else None,
+        "timestamp": _get_event_timestamp(event),
         "name": _get_event_name(event),
+        "description": _get_event_description(event)
     }
-    description = _get_event_description(event)
-    if description:
-        result["description"] = description
-
-    # Include deleted status if the event is deleted
-    if _is_event_deleted(event):
-        result["deleted"] = True
 
     # Add any extra custom fields
     for key, value in event.metadata.items():
-        if key not in ("timestamp", "name", "description", "deleted"):
+        if key not in ("timestamp", "name", "description"):
             result[key] = value
 
     return result
-
-
-def _get_event_identity(metadata: MetadataRecord) -> tuple[int | None, str]:
-    """Get the unique identity of an event (timestamp, name)."""
-    return (_get_event_timestamp(metadata), _get_event_name(metadata))
-
-
-def _get_deleted_event_identities(
-    all_metadata: list[MetadataRecord],
-) -> set[tuple[int | None, str]]:
-    """Build a set of deleted event identities from metadata records.
-
-    Soft delete works by appending a copy of the event with deleted=true.
-    This function finds all events marked as deleted and returns their identities.
-    """
-    deleted_identities: set[tuple[int | None, str]] = set()
-    for metadata in all_metadata:
-        if _is_event_metadata(metadata) and _is_event_deleted(metadata):
-            deleted_identities.add(_get_event_identity(metadata))
-    return deleted_identities
 
 
 def list_events_mcap(
@@ -178,7 +157,6 @@ def list_events_mcap(
     name: str | None = None,
     start_time: float | None = None,
     end_time: float | None = None,
-    include_deleted: bool = False,
     output_json: bool = False,
 ) -> None:
     """List events in an MCAP file."""
@@ -188,24 +166,13 @@ def list_events_mcap(
     with McapRecordReaderFactory.from_file(input_path) as reader:
         all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
 
-        # Build set of deleted event identities for filtering
-        deleted_identities = _get_deleted_event_identities(all_metadata)
-
         # Filter events - also check if event identity is in deleted set
-        events: list[MetadataRecord] = []
-        for m in all_metadata:
-            if not _is_event_metadata(m):
-                continue
-            # Skip records that are explicitly marked as deleted
-            if _is_event_deleted(m):
-                continue
-            # Skip events whose identity matches a deleted event (unless include_deleted)
-            if not include_deleted and _get_event_identity(m) in deleted_identities:
-                continue
-            # Apply other filters (name, time range)
-            if not _event_matches_filters(m, name, start_ns, end_ns, include_deleted=True):
-                continue
-            events.append(m)
+        events: list[MetadataRecord] = [
+            m for m in all_metadata
+            if _is_event_metadata(m)
+            and _event_matches_name(m, name)
+            and _event_matches_timestamp(m, start_ns, end_ns)
+        ]
 
         if output_json:
             print(json.dumps([_event_to_json(e) for e in events], indent=2))
@@ -220,7 +187,6 @@ def list_events(
     name: str | None = None,
     start_time: float | None = None,
     end_time: float | None = None,
-    include_deleted: bool = False,
     output_json: bool = False,
 ) -> None:
     """List events in an MCAP or bag file."""
@@ -233,11 +199,10 @@ def list_events(
             name=name,
             start_time=start_time,
             end_time=end_time,
-            include_deleted=include_deleted,
             output_json=output_json,
         )
     else:
-        print("Events are not supported in bag format.")
+        raise ValueError("Events are not supported in bag format.")
 
 
 #####################
@@ -280,17 +245,15 @@ def add_event_mcap(
     if extra_fields:
         event_metadata.update(extra_fields)
 
-    new_event = MetadataRecord(name=EVENT_METADATA_NAME, metadata=event_metadata)
-
+    # TODO: Replace this with the public writer append api
     # Load existing summary from the file using FileReader (for peek support)
+    new_event = MetadataRecord(name=EVENT_METADATA_NAME, metadata=event_metadata)
     summary = McapSummaryFactory.create_summary(
         file=FileReader(input_path),
         load_summary_eagerly=True,
-    )
-
+   )
     # Open file for reading and writing (append mode)
     file_writer = FileWriter(input_path, mode="r+b")
-
     # Create writer in append mode - this will seek to before the data end record
     # and set up the CRC writer with the existing CRC
     with McapRecordWriterFactory.create_writer(
@@ -308,7 +271,7 @@ def add_event_mcap(
 def add_event(
     input_path: str | Path,
     event_name: str,
-    timestamp: float,
+    timestamp: int,
     output_path: str | Path | None = None,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
@@ -322,9 +285,8 @@ def add_event(
     Args:
         input_path: Path to the input MCAP file.
         event_name: Name of the event.
-        timestamp: Event timestamp in seconds.
-        output_path: If provided, copy the MCAP and add event to the copy.
-            If None, append the event in place.
+        timestamp: Event timestamp in nanoseconds.
+        output_path: If provided, copy the MCAP and add event to the copy. If None, append the event in place.
         description: Optional event description.
         extra_fields: Optional extra key-value pairs to include in the event.
         chunk_size: Target chunk size for output (only used with output_path).
@@ -334,13 +296,12 @@ def add_event(
     Returns:
         Path to the file with the event added.
     """
-    from pybag.cli.filter import filter_mcap
-
     input_path = Path(input_path).resolve()
     file_format = get_file_format_from_magic(input_path)
 
     if file_format != "mcap":
         raise ValueError("Events are not supported in bag format.")
+    _ = validate_compression_for_mcap(chunk_compression)
 
     if output_path is None:
         # Append in place
@@ -357,20 +318,11 @@ def add_event(
 
         if output_path == input_path:
             raise ValueError('Input path cannot be same as output.')
-
         if not overwrite and output_path.exists():
             raise ValueError('Output mcap exists. Please set `overwrite` to True.')
 
-        # First, copy the MCAP using filter (no filters = full copy)
-        filter_mcap(
-            input_path,
-            output_path=output_path,
-            chunk_size=chunk_size,
-            chunk_compression=chunk_compression,
-            overwrite=overwrite,
-        )
-
-        # Then append the event to the copy
+        # Append the event to the copy
+        shutil.copyfile(input_path, output_path)
         return add_event_mcap(
             output_path,
             event_name,
@@ -384,77 +336,7 @@ def add_event(
 # Event Deletion    #
 #####################
 
-def soft_delete_events_mcap(
-    input_path: str | Path,
-    name: str | None = None,
-    start_time: float | None = None,
-    end_time: float | None = None,
-) -> tuple[Path, int]:
-    """Soft delete events by marking them with deleted=true.
-
-    This function appends new metadata records that mark matching events as
-    deleted without rewriting the entire file. The original event records
-    remain in the file but will be filtered out by default when listing.
-
-    Args:
-        input_path: Path to the MCAP file to modify.
-        name: Filter events to delete by name.
-        start_time: Filter events with timestamp >= start_time (seconds).
-        end_time: Filter events with timestamp <= end_time (seconds).
-
-    Returns:
-        Tuple of (path to modified file, number of events marked as deleted).
-    """
-    input_path = Path(input_path).resolve()
-    start_ns = _to_ns(start_time)
-    end_ns = _to_ns(end_time)
-
-    # Find events to delete
-    events_to_delete: list[MetadataRecord] = []
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        for metadata in all_metadata:
-            if _is_event_metadata(metadata) and _event_matches_filters(
-                metadata, name, start_ns, end_ns, include_deleted=False
-            ):
-                events_to_delete.append(metadata)
-
-    if not events_to_delete:
-        logger.warning("No events match the deletion criteria.")
-        return input_path, 0
-
-    # Load existing summary from the file using FileReader (for peek support)
-    summary = McapSummaryFactory.create_summary(
-        file=FileReader(input_path),
-        load_summary_eagerly=True,
-    )
-
-    # Open file for reading and writing (append mode)
-    file_writer = FileWriter(input_path, mode="r+b")
-
-    # Create writer in append mode
-    with McapRecordWriterFactory.create_writer(
-        file_writer,
-        summary,
-        mode='a',
-        chunk_size=1024 * 1024,
-    ) as writer:
-        # Write new metadata records marking events as deleted
-        for event in events_to_delete:
-            # Copy existing metadata and add deleted flag
-            deleted_metadata = dict(event.metadata)
-            deleted_metadata["deleted"] = "true"
-            deleted_event = MetadataRecord(
-                name=EVENT_METADATA_NAME,
-                metadata=deleted_metadata,
-            )
-            writer.write_metadata(deleted_event)
-
-    logger.info(f"Soft deleted {len(events_to_delete)} event(s).")
-    return input_path, len(events_to_delete)
-
-
-def hard_delete_events_mcap(
+def delete_events_mcap(
     input_path: str | Path,
     output_path: str | Path | None = None,
     name: str | None = None,
@@ -469,10 +351,8 @@ def hard_delete_events_mcap(
 
     Args:
         input_path: Path to input MCAP file.
-        output_path: Path to output MCAP file. If None, defaults to
-            <input_stem>_filtered.mcap.
-        name: Filter events to delete by name. If None, all events matching
-            other filters will be deleted.
+        output_path: Path to output MCAP file. If None, defaults to <input_stem>_filtered.mcap.
+        name: Filter events to delete by name. If None, all events matching other filters will be deleted.
         start_time: Filter events to delete with timestamp >= start_time (seconds).
         end_time: Filter events to delete with timestamp <= end_time (seconds).
         chunk_size: Target chunk size in bytes for the output file.
@@ -483,8 +363,7 @@ def hard_delete_events_mcap(
         Path to the output MCAP file.
 
     Raises:
-        ValueError: If input and output paths are the same, or if output exists
-            and overwrite is False.
+        ValueError: If input and output paths are the same, or if output exists and overwrite is False.
     """
     input_path = Path(input_path).resolve()
     if output_path is None:
@@ -500,6 +379,7 @@ def hard_delete_events_mcap(
     start_ns = _to_ns(start_time)
     end_ns = _to_ns(end_time)
 
+    # TODO: Simplify because we onlly need to delete relevant metadata records
     with McapRecordReaderFactory.from_file(input_path) as reader:
         all_channels = reader.get_channels()
         topic_to_channel_ids: dict[str, set[int]] = defaultdict(set)
@@ -585,13 +465,9 @@ def delete_events(
     chunk_size: int | None = None,
     chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
     *,
-    force: bool = False,
     overwrite: bool = False,
-) -> tuple[Path, int]:
+) -> Path:
     """Delete events from an MCAP or bag file.
-
-    By default, performs a soft delete by marking events with deleted=true.
-    Use force=True to perform a hard delete that rewrites the file.
 
     Args:
         input_path: Path to input file.
@@ -601,7 +477,6 @@ def delete_events(
         end_time: Filter events with timestamp <= end_time (seconds).
         chunk_size: Target chunk size for output (only used for hard delete).
         chunk_compression: Compression algorithm (only used for hard delete).
-        force: If True, performs hard delete (rewrites file). Default is soft delete.
         overwrite: Whether to overwrite output file if it exists.
 
     Returns:
@@ -612,30 +487,19 @@ def delete_events(
 
     if file_format != "mcap":
         raise ValueError("Events are not supported in bag format.")
+    _ = validate_compression_for_mcap(chunk_compression)
 
-    if force:
-        # Hard delete: rewrite the file without matching events
-        result_path = hard_delete_events_mcap(
-            input_path,
-            output_path=output_path,
-            name=name,
-            start_time=start_time,
-            end_time=end_time,
-            chunk_size=chunk_size,
-            chunk_compression=chunk_compression,
-            overwrite=overwrite,
-        )
-        # Count deleted events for return value
-        # (hard_delete_events_mcap logs but doesn't return count)
-        return result_path, -1  # -1 indicates count not available
-    else:
-        # Soft delete: mark events as deleted without rewriting
-        return soft_delete_events_mcap(
-            input_path,
-            name=name,
-            start_time=start_time,
-            end_time=end_time,
-        )
+    # Hard delete: rewrite the file without matching events
+    return delete_events_mcap(
+        input_path,
+        output_path=output_path,
+        name=name,
+        start_time=start_time,
+        end_time=end_time,
+        chunk_size=chunk_size,
+        chunk_compression=chunk_compression,
+        overwrite=overwrite,
+    )
 
 
 #####################
@@ -646,8 +510,8 @@ def clip_event_mcap(
     input_path: str | Path,
     event_name: str,
     output_path: str | Path | None = None,
-    before: float = 5.0,
-    after: float = 5.0,
+    before_timestamp: float = 5.0,
+    after_timestamp: float = 5.0,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -663,14 +527,10 @@ def clip_event_mcap(
     Args:
         input_path: Path to input MCAP file.
         event_name: Name of the event to clip around.
-        output_path: Path to output MCAP file. If None, defaults to
-            <input_stem>_clip_<event_name>.mcap.
-        before: Time in seconds to include before the event. Clips from
-            (event_time - before) to (event_time + after). Default: 5.0.
-        after: Time in seconds to include after the event. Clips from
-            (event_time - before) to (event_time + after). Default: 5.0.
-        include_topics: List of topic patterns to include (glob patterns supported).
-            If None, all topics are included.
+        output_path: Path to output MCAP file. If None, defaults to <input_stem>_clip_<event_name>.mcap.
+        before_timestamp: Time in seconds to include before the event. Clips from (event_time - before) to (event_time + after).
+        after_timestamp: Time in seconds to include after the event. Clips from (event_time - before) to (event_time + after).
+        include_topics: List of topic patterns to include (glob patterns supported). If None, all topics are included.
         exclude_topics: List of topic patterns to exclude (glob patterns supported).
         chunk_size: Target chunk size in bytes for the output file.
         chunk_compression: Compression algorithm for chunks.
@@ -682,46 +542,36 @@ def clip_event_mcap(
     Raises:
         ValueError: If no event with the given name is found.
     """
-    from pybag.cli.filter import filter_mcap
-
     input_path = Path(input_path).resolve()
+    _ = validate_compression_for_mcap(chunk_compression)
 
-    # Find the event (excluding soft-deleted events)
+    # Get all the relevant metadata records
     with McapRecordReaderFactory.from_file(input_path) as reader:
         all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
 
-        # Build set of deleted event identities
-        deleted_identities = _get_deleted_event_identities(all_metadata)
-
-        # Find matching non-deleted events
         matching_events = [
             m for m in all_metadata
             if _is_event_metadata(m)
             and _get_event_name(m) == event_name
-            and not _is_event_deleted(m)
-            and _get_event_identity(m) not in deleted_identities
         ]
-
         if not matching_events:
             raise ValueError(f"No event found with name '{event_name}'")
-
-        if len(matching_events) > 1:
-            # Use the first event and warn
-            logger.warning(
-                f"Multiple events found with name '{event_name}'. "
-                f"Using the first one (timestamp: {_ns_to_seconds(_get_event_timestamp(matching_events[0])):.6f}s)"
-            )
 
         event = matching_events[0]
         event_timestamp_ns = _get_event_timestamp(event)
         if event_timestamp_ns is None:
             raise ValueError(f"Event '{event_name}' has no timestamp")
-
-    event_timestamp_s = _ns_to_seconds(event_timestamp_ns)
+        if len(matching_events) > 1:
+            # Use the first event and warn
+            logger.warning(
+                f"Multiple events found with name '{event_name}'. "
+                f"Using the first one (timestamp: {_to_s(event_timestamp_ns):.6f}s)"
+            )
 
     # Calculate clip time range
-    start_time = event_timestamp_s - before
-    end_time = event_timestamp_s + after
+    event_timestamp_s = _ns_to_seconds(event_timestamp_ns)
+    start_time = event_timestamp_s - before_timestamp
+    end_time = event_timestamp_s + after_timestamp
 
     # Default output path
     if output_path is None:
@@ -746,8 +596,8 @@ def clip_event(
     input_path: str | Path,
     event_name: str,
     output_path: str | Path | None = None,
-    before: float = 5.0,
-    after: float = 5.0,
+    before_timestamp: float = 5.0,
+    after_timestamp: float = 5.0,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -764,8 +614,8 @@ def clip_event(
             input_path,
             event_name,
             output_path=output_path,
-            before=before,
-            after=after,
+            before_timestamp=before_timestamp,
+            after_timestamp=after_timestamp,
             include_topics=include_topics,
             exclude_topics=exclude_topics,
             chunk_size=chunk_size,
@@ -787,39 +637,29 @@ def _run_list(args) -> None:
         name=args.name,
         start_time=args.start_time,
         end_time=args.end_time,
-        include_deleted=getattr(args, 'include_deleted', False),
         output_json=args.output_json,
     )
 
 
 def _run_add(args) -> None:
     """Run the event add command."""
-    from pybag.cli.utils import validate_compression_for_mcap
-
     # Parse extra key-value pairs
-    extra_fields: dict[str, str] | None = None
-    if args.extra:
-        extra_fields = {}
-        for item in args.extra:
-            if "=" not in item:
-                raise ValueError(f"Invalid extra field format: {item}. Expected 'key=value'")
-            key, value = item.split("=", 1)
-            extra_fields[key] = value
-
-    output_path = getattr(args, 'output', None)
-    chunk_compression = validate_compression_for_mcap(
-        getattr(args, 'chunk_compression', None)
-    )
+    extra_fields: dict[str, str] = {}
+    for item in args.extra:
+        if "=" not in item:
+            raise ValueError(f"Invalid extra field format: {item}. Expected 'key=value'")
+        key, value = item.split("=", 1)
+        extra_fields[key] = value
 
     file_path = add_event(
         args.input,
         args.name,
-        args.timestamp,
-        output_path=output_path,
+        _seconds_to_ns(args.time * 1_000_000_000),
+        output_path=args.output,
         description=args.description,
         extra_fields=extra_fields,
         chunk_size=getattr(args, 'chunk_size', None),
-        chunk_compression=chunk_compression,
+        chunk_compression=args.chunk_compression,
         overwrite=getattr(args, 'overwrite', False),
     )
     print(f"Event added to: {file_path}")
@@ -827,54 +667,27 @@ def _run_add(args) -> None:
 
 def _run_delete(args) -> None:
     """Run the event delete command."""
-    from pybag.cli.utils import validate_compression_for_mcap
-
-    if args.output:
-        # Hard delete: copy MCAP and remove events from the copy
-        chunk_compression = validate_compression_for_mcap(args.chunk_compression)
-        output_path, _ = delete_events(
-            args.input,
-            output_path=args.output,
-            name=args.name,
-            start_time=args.start_time,
-            end_time=args.end_time,
-            chunk_size=args.chunk_size,
-            chunk_compression=chunk_compression,
-            force=True,
-            overwrite=args.overwrite,
-        )
-        print(f"Events deleted. Output written to: {output_path}")
-    else:
-        # Soft delete: modify in place
-        output_path, count = delete_events(
-            args.input,
-            name=args.name,
-            start_time=args.start_time,
-            end_time=args.end_time,
-            force=False,
-        )
-        if count == 0:
-            print("No events matched the deletion criteria.")
-        else:
-            print(f"Marked {count} event(s) as deleted in: {output_path}")
+    # Hard delete: copy MCAP and remove events from the copy
+    output_path = delete_events(
+        args.input,
+        output_path=args.output,
+        name=args.name,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        chunk_size=args.chunk_size,
+        chunk_compression=args.chunk_compression,
+        overwrite=args.overwrite,
+    )
+    print(f"Events deleted. Output written to: {output_path}")
 
 
 def _run_clip(args) -> None:
     """Run the event clip command."""
-    from pybag.cli.utils import validate_compression_for_mcap
-
-    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
-
     # Handle --margin flag: it's a CLI convenience that sets both before and after
     if args.margin is not None:
         if args.before is not None or args.after is not None:
             raise ValueError("Cannot use --margin together with --before or --after")
-        before = args.margin
-        after = args.margin
-    elif args.before is None and args.after is None:
-        # Default to 5s margin if nothing specified
-        before = 5.0
-        after = 5.0
+        before, after = args.margin
     else:
         # Use 0 for unspecified values (clip up to or from event time)
         before = args.before if args.before is not None else 0.0
@@ -884,12 +697,12 @@ def _run_clip(args) -> None:
         args.input,
         args.name,
         output_path=args.output,
-        before=before,
-        after=after,
+        before_timestamp=before,
+        after_timestamp=after,
         include_topics=args.include_topic,
         exclude_topics=args.exclude_topic,
         chunk_size=args.chunk_size,
-        chunk_compression=chunk_compression,
+        chunk_compression=args.chunk_compression,
         overwrite=args.overwrite,
     )
     print(f"Clipped around event '{args.name}'. Output written to: {output_path}")
@@ -907,12 +720,6 @@ def add_parser(subparsers) -> None:
 
             Events are stored as metadata records with a special name. Each event
             has a timestamp, a name, and an optional description.
-
-            Subcommands:
-              pybag event list <file>                - List all events
-              pybag event add <file> <name> <time>   - Add a new event
-              pybag event delete <file>              - Delete events
-              pybag event clip <file> <name>         - Clip MCAP around an event
 
             Note: Events are only supported in MCAP format, not bag files.
         """),
@@ -947,12 +754,6 @@ def add_parser(subparsers) -> None:
         dest="output_json",
         help="Output in JSON format",
     )
-    list_parser.add_argument(
-        "--include-deleted",
-        action="store_true",
-        dest="include_deleted",
-        help="Include events that have been soft deleted",
-    )
     list_parser.set_defaults(func=_run_list)
 
     # Add subcommand
@@ -965,17 +766,13 @@ def add_parser(subparsers) -> None:
 
             By default, the event is appended directly to the input file.
             Use -o to copy the MCAP and add the event to the copy instead.
-
-            Example:
-              pybag event add recording.mcap "collision" 10.5 --description "Hit obstacle"
-              pybag event add recording.mcap "start" 0.0
-              pybag event add recording.mcap "event" 5.0 -o output.mcap  # copy mode
         """),
     )
     add_parser_cmd.add_argument("input", help="Path to MCAP file (*.mcap)")
     add_parser_cmd.add_argument("name", help="Name of the event (e.g., 'start', 'collision')")
     add_parser_cmd.add_argument(
-        "timestamp",
+        "time",
+        required=True,
         type=float,
         help="Timestamp of the event in seconds",
     )
@@ -1018,23 +815,12 @@ def add_parser(subparsers) -> None:
         description=dedent("""
             Delete events from an MCAP file. Use filters to select which events
             to delete. If no filters are provided, all events will be deleted.
-
-            By default, events are soft deleted by marking them with a "deleted"
-            flag. This modifies the file in place without rewriting it. Soft
-            deleted events are hidden from listing by default but can be shown
-            with --include-deleted.
-
-            Use -o to copy the MCAP and hard delete (remove) the events from the
-            copy instead of soft deleting in place.
-
-            Example:
-              pybag event delete recording.mcap --name "collision"  # soft delete
-              pybag event delete recording.mcap -o clean.mcap  # hard delete to copy
         """),
     )
     delete_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
     delete_parser.add_argument(
         "-o", "--output",
+        required=True,
         help="Output file path. If specified, copies MCAP and removes events from copy.",
     )
     delete_parser.add_argument(
@@ -1083,14 +869,6 @@ def add_parser(subparsers) -> None:
               --before X      Clip from (event_time - X) to event_time
               --after X       Clip from event_time to (event_time + X)
               --before X --after Y  Clip from (event_time - X) to (event_time + Y)
-
-            If no time options are specified, defaults to --margin 5.
-
-            Example:
-              pybag event clip recording.mcap "collision" --margin 5
-              pybag event clip recording.mcap "start" --before 2
-              pybag event clip recording.mcap "end" --after 10
-              pybag event clip recording.mcap "incident" --before 5 --after 10
         """),
     )
     clip_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -241,8 +241,11 @@ def add_event_mcap(
         "name": event_name,
         "description": description or ""
     }
-    if extra_fields:
-        event_metadata.update(extra_fields)
+    for key, value in (extra_fields or {}).items():
+        if key not in ("timestamp", "name", "description"):
+            event_metadata[key] = value
+        else:
+            raise ValueError(f"'{key}' is reserved")
 
     # Write metadata record in append
     with McapFileWriter.open(

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 from typing import Literal
 
 from pybag.cli.utils import get_file_format_from_magic
+from pybag.io.raw_reader import FileReader
 from pybag.io.raw_writer import FileWriter
 from pybag.mcap.record_reader import McapRecordReaderFactory
 from pybag.mcap.record_writer import McapRecordWriterFactory
@@ -197,46 +198,26 @@ def add_event_mcap(
     input_path: str | Path,
     event_name: str,
     timestamp: float,
-    output_path: str | Path | None = None,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
-    chunk_size: int | None = None,
-    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
-    *,
-    overwrite: bool = False,
 ) -> Path:
-    """Add an event to an MCAP file.
+    """Add an event to an MCAP file by appending in place.
+
+    This function appends a new event metadata record to an existing MCAP file
+    without rewriting the entire file. The event is written at the end of the
+    data section and the summary section is updated accordingly.
 
     Args:
-        input_path: Path to input MCAP file.
+        input_path: Path to the MCAP file to modify.
         event_name: Name of the event.
         timestamp: Event timestamp in seconds.
-        output_path: Path to output MCAP file. If None, defaults to
-            <input_stem>_with_event.mcap.
         description: Optional event description.
         extra_fields: Optional extra key-value pairs to include in the event.
-        chunk_size: Target chunk size in bytes for the output file.
-        chunk_compression: Compression algorithm for chunks.
-        overwrite: Whether to overwrite the output file if it exists.
 
     Returns:
-        Path to the output MCAP file.
-
-    Raises:
-        ValueError: If input and output paths are the same, or if output exists
-            and overwrite is False.
+        Path to the modified MCAP file (same as input_path).
     """
     input_path = Path(input_path).resolve()
-    if output_path is None:
-        output_path = input_path.with_name(f"{input_path.stem}_with_event.mcap")
-    output_path = Path(output_path).resolve()
-
-    if output_path == input_path:
-        raise ValueError('Input path cannot be same as output.')
-
-    if not overwrite and output_path.exists():
-        raise ValueError('Output mcap exists. Please set `overwrite` to True.')
-
     timestamp_ns = _to_ns(timestamp)
 
     # Build the event metadata
@@ -251,78 +232,37 @@ def add_event_mcap(
 
     new_event = MetadataRecord(name=EVENT_METADATA_NAME, metadata=event_metadata)
 
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        all_channels = reader.get_channels()
-        topic_to_channel_ids: dict[str, set[int]] = defaultdict(set)
-        for channel_id, channel in all_channels.items():
-            topic_to_channel_ids[channel.topic].add(channel_id)
+    # Load existing summary from the file using FileReader (for peek support)
+    summary = McapSummaryFactory.create_summary(
+        file=FileReader(input_path),
+        load_summary_eagerly=True,
+    )
 
-        all_attachments = reader.get_attachments()
-        all_metadata = reader.get_metadata()
+    # Open file for reading and writing (append mode)
+    file_writer = FileWriter(input_path, mode="r+b")
 
-        with McapRecordWriterFactory.create_writer(
-            FileWriter(output_path),
-            McapSummaryFactory.create_summary(chunk_size=chunk_size),
-            chunk_size=chunk_size,
-            chunk_compression=chunk_compression,
-            profile=reader.get_header().profile,
-        ) as writer:
-            # Write message records
-            written_schema_ids: set[int] = set()
-            written_channel_ids: set[int] = set()
-            sequence_counters: dict[int, int] = defaultdict(int)
+    # Create writer in append mode - this will seek to before the data end record
+    # and set up the CRC writer with the existing CRC
+    with McapRecordWriterFactory.create_writer(
+        file_writer,
+        summary,
+        mode='a',
+        chunk_size=1024 * 1024,  # Default chunk size (not used for metadata)
+    ) as writer:
+        # Only write the new event metadata - all other records are preserved
+        writer.write_metadata(new_event)
 
-            for msg_record in reader.get_messages(in_log_time_order=False):
-                # Write the schema record the first time
-                schema_id = all_channels[msg_record.channel_id].schema_id
-                if schema_id != 0 and schema_id not in written_schema_ids:
-                    if (schema := reader.get_schema(schema_id)) is not None:
-                        writer.write_schema(schema)
-                        written_schema_ids.add(schema_id)
-
-                # Write the channel record the first time
-                if msg_record.channel_id not in written_channel_ids:
-                    writer.write_channel(all_channels[msg_record.channel_id])
-                    written_channel_ids.add(msg_record.channel_id)
-
-                # Write message with updated sequence number
-                new_record = MessageRecord(
-                    channel_id=msg_record.channel_id,
-                    sequence=sequence_counters[msg_record.channel_id],
-                    log_time=msg_record.log_time,
-                    publish_time=msg_record.publish_time,
-                    data=msg_record.data,
-                )
-                sequence_counters[msg_record.channel_id] += 1
-                writer.write_message(new_record)
-
-            # Write attachments
-            for attachment in all_attachments:
-                writer.write_attachment(attachment)
-
-            # Write existing metadata
-            for metadata in all_metadata:
-                writer.write_metadata(metadata)
-
-            # Write the new event
-            writer.write_metadata(new_event)
-
-    return output_path
+    return input_path
 
 
 def add_event(
     input_path: str | Path,
     event_name: str,
     timestamp: float,
-    output_path: str | Path | None = None,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
-    chunk_size: int | None = None,
-    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
-    *,
-    overwrite: bool = False,
 ) -> Path:
-    """Add an event to an MCAP or bag file."""
+    """Add an event to an MCAP file by appending in place."""
     input_path = Path(input_path).resolve()
     file_format = get_file_format_from_magic(input_path)
 
@@ -331,12 +271,8 @@ def add_event(
             input_path,
             event_name,
             timestamp,
-            output_path=output_path,
             description=description,
             extra_fields=extra_fields,
-            chunk_size=chunk_size,
-            chunk_compression=chunk_compression,
-            overwrite=overwrite,
         )
     else:
         raise ValueError("Events are not supported in bag format.")
@@ -515,10 +451,6 @@ def _run_list(args) -> None:
 
 def _run_add(args) -> None:
     """Run the event add command."""
-    from pybag.cli.utils import validate_compression_for_mcap
-
-    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
-
     # Parse extra key-value pairs
     extra_fields: dict[str, str] | None = None
     if args.extra:
@@ -529,18 +461,14 @@ def _run_add(args) -> None:
             key, value = item.split("=", 1)
             extra_fields[key] = value
 
-    output_path = add_event(
+    file_path = add_event(
         args.input,
         args.name,
         args.timestamp,
-        output_path=args.output,
         description=args.description,
         extra_fields=extra_fields,
-        chunk_size=args.chunk_size,
-        chunk_compression=chunk_compression,
-        overwrite=args.overwrite,
     )
-    print(f"Event added. Output written to: {output_path}")
+    print(f"Event added to: {file_path}")
 
 
 def _run_delete(args) -> None:
@@ -620,24 +548,21 @@ def add_parser(subparsers) -> None:
         "add",
         help="Add an event to an MCAP file.",
         description=dedent("""
-            Add a new event to an MCAP file. Events are markers with a timestamp
+            Add a new event to an MCAP file. The event is appended directly to
+            the file without creating a copy. Events are markers with a timestamp
             and name that indicate when something significant happened.
 
             Example:
               pybag event add recording.mcap "collision" 10.5 --description "Hit obstacle"
-              pybag event add recording.mcap "start" 0.0 -o output.mcap
+              pybag event add recording.mcap "start" 0.0
         """),
     )
-    add_parser_cmd.add_argument("input", help="Path to input MCAP file (*.mcap)")
+    add_parser_cmd.add_argument("input", help="Path to MCAP file (*.mcap)")
     add_parser_cmd.add_argument("name", help="Name of the event (e.g., 'start', 'collision')")
     add_parser_cmd.add_argument(
         "timestamp",
         type=float,
         help="Timestamp of the event in seconds",
-    )
-    add_parser_cmd.add_argument(
-        "-o", "--output",
-        help="Output file path. If not specified, creates <input>_with_event.mcap",
     )
     add_parser_cmd.add_argument(
         "--description",
@@ -648,22 +573,6 @@ def add_parser(subparsers) -> None:
         action="append",
         metavar="KEY=VALUE",
         help="Extra key-value pair to include in the event (can be used multiple times)",
-    )
-    add_parser_cmd.add_argument(
-        "--chunk-size",
-        type=int,
-        help="Chunk size of the output file in bytes",
-    )
-    add_parser_cmd.add_argument(
-        "--chunk-compression",
-        type=str,
-        choices=["lz4", "zstd", "none"],
-        help="Compression used for chunk records",
-    )
-    add_parser_cmd.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite output file if it exists",
     )
     add_parser_cmd.set_defaults(func=_run_add)
 

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -10,7 +10,6 @@ import logging
 import shutil
 from pathlib import Path
 from textwrap import dedent
-from tkinter.constants import FALSE
 from typing import Literal
 
 from pybag.cli.filter import filter_mcap
@@ -214,6 +213,8 @@ def add_event_mcap(
     timestamp: float,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
 ) -> Path:
     """Add an event to an MCAP file by appending in place.
 
@@ -244,7 +245,12 @@ def add_event_mcap(
         event_metadata.update(extra_fields)
 
     # Write metadata record in append
-    with McapFileWriter.open(input_path, mode='a') as writer:
+    with McapFileWriter.open(
+        input_path,
+        mode='a',
+        chunk_size=chunk_size,
+        chunk_compression=chunk_compression
+    ) as writer:
         writer.write_metadata(EVENT_METADATA_NAME, event_metadata)
 
     return input_path
@@ -253,7 +259,7 @@ def add_event_mcap(
 def add_event(
     input_path: str | Path,
     event_name: str,
-    timestamp: int,
+    timestamp: float,
     output_path: str | Path | None = None,
     description: str | None = None,
     extra_fields: dict[str, str] | None = None,
@@ -267,7 +273,7 @@ def add_event(
     Args:
         input_path: Path to the input MCAP file.
         event_name: Name of the event.
-        timestamp: Event timestamp in nanoseconds.
+        timestamp: Event timestamp in seconds.
         output_path: If provided, copy the MCAP and add event to the copy. If None, append the event in place.
         description: Optional event description.
         extra_fields: Optional extra key-value pairs to include in the event.
@@ -293,6 +299,8 @@ def add_event(
             timestamp,
             description=description,
             extra_fields=extra_fields,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
         )
     else:
         # Copy MCAP and add event to the copy
@@ -311,6 +319,8 @@ def add_event(
             timestamp,
             description=description,
             extra_fields=extra_fields,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
         )
 
 
@@ -595,7 +605,7 @@ def _run_add(args) -> None:
     """Run the event add command."""
     # Parse extra key-value pairs
     extra_fields: dict[str, str] = {}
-    for item in args.extra:
+    for item in args.extra or []:
         if "=" not in item:
             raise ValueError(f"Invalid extra field format: {item}. Expected 'key=value'")
         key, value = item.split("=", 1)
@@ -604,13 +614,13 @@ def _run_add(args) -> None:
     file_path = add_event(
         args.input,
         args.name,
-        _seconds_to_ns(args.time * 1_000_000_000),
+        args.time,
         output_path=args.output,
         description=args.description,
         extra_fields=extra_fields,
-        chunk_size=getattr(args, 'chunk_size', None),
+        chunk_size=args.chunk_size,
         chunk_compression=args.chunk_compression,
-        overwrite=getattr(args, 'overwrite', False),
+        overwrite=args.overwrite,
     )
     print(f"Event added to: {file_path}")
 
@@ -637,7 +647,8 @@ def _run_clip(args) -> None:
     if args.margin is not None:
         if args.before is not None or args.after is not None:
             raise ValueError("Cannot use --margin together with --before or --after")
-        before, after = args.margin
+        before = args.margin
+        after = args.margin
     else:
         # Use 0 for unspecified values (clip up to or from event time)
         before = args.before if args.before is not None else 0.0
@@ -722,7 +733,6 @@ def add_parser(subparsers) -> None:
     add_parser_cmd.add_argument("name", help="Name of the event (e.g., 'start', 'collision')")
     add_parser_cmd.add_argument(
         "time",
-        required=True,
         type=float,
         help="Timestamp of the event in seconds",
     )

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -125,7 +125,7 @@ def _print_event_table(events: list[MetadataRecord]) -> None:
     # Print rows
     for event in events:
         timestamp = _get_event_timestamp(event)
-        timestamp_s = f"{_ns_to_seconds(timestamp):.6f}" if timestamp else "N/A"
+        timestamp_s = f"{_ns_to_seconds(timestamp):.6f}" if timestamp is not None else "N/A"
         name = _get_event_name(event)
         description = _get_event_description(event)
         if len(description) > 50:

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -435,6 +435,148 @@ def delete_events(
 
 
 #####################
+# Event Clipping    #
+#####################
+
+def clip_event_mcap(
+    input_path: str | Path,
+    event_name: str,
+    output_path: str | Path | None = None,
+    before: float | None = None,
+    after: float | None = None,
+    include_topics: list[str] | None = None,
+    exclude_topics: list[str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Clip an MCAP file around an event.
+
+    Extracts a portion of an MCAP file centered on an event's timestamp,
+    including a specified time margin before and after the event.
+
+    Args:
+        input_path: Path to input MCAP file.
+        event_name: Name of the event to clip around.
+        output_path: Path to output MCAP file. If None, defaults to
+            <input_stem>_clip_<event_name>.mcap.
+        before: Time in seconds to include before the event. If None and after
+            is specified, uses the same value as after. If both are None,
+            defaults to 5.0 seconds.
+        after: Time in seconds to include after the event. If None and before
+            is specified, uses the same value as before. If both are None,
+            defaults to 5.0 seconds.
+        include_topics: List of topic patterns to include (glob patterns supported).
+            If None, all topics are included.
+        exclude_topics: List of topic patterns to exclude (glob patterns supported).
+        chunk_size: Target chunk size in bytes for the output file.
+        chunk_compression: Compression algorithm for chunks.
+        overwrite: Whether to overwrite the output file if it exists.
+
+    Returns:
+        Path to the output MCAP file.
+
+    Raises:
+        ValueError: If no event with the given name is found, or if multiple
+            events match and it's ambiguous which one to use.
+    """
+    from pybag.cli.filter import filter_mcap
+
+    input_path = Path(input_path).resolve()
+
+    # Handle symmetric margins: if only one is given, use it for both
+    if before is None and after is None:
+        before = 5.0
+        after = 5.0
+    elif before is None:
+        before = after
+    elif after is None:
+        after = before
+
+    # Find the event
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        matching_events = [
+            m for m in all_metadata
+            if _is_event_metadata(m) and _get_event_name(m) == event_name
+        ]
+
+        if not matching_events:
+            raise ValueError(f"No event found with name '{event_name}'")
+
+        if len(matching_events) > 1:
+            # Use the first event and warn
+            logger.warning(
+                f"Multiple events found with name '{event_name}'. "
+                f"Using the first one (timestamp: {_ns_to_seconds(_get_event_timestamp(matching_events[0])):.6f}s)"
+            )
+
+        event = matching_events[0]
+        event_timestamp_ns = _get_event_timestamp(event)
+        if event_timestamp_ns is None:
+            raise ValueError(f"Event '{event_name}' has no timestamp")
+
+    event_timestamp_s = _ns_to_seconds(event_timestamp_ns)
+
+    # Calculate clip time range
+    start_time = event_timestamp_s - before
+    end_time = event_timestamp_s + after
+
+    # Default output path
+    if output_path is None:
+        safe_name = event_name.replace("/", "_").replace(" ", "_")
+        output_path = input_path.with_name(f"{input_path.stem}_clip_{safe_name}.mcap")
+
+    # Use the filter function to do the actual clipping
+    return filter_mcap(
+        input_path,
+        output_path=output_path,
+        include_topics=include_topics,
+        exclude_topics=exclude_topics,
+        start_time=start_time,
+        end_time=end_time,
+        chunk_size=chunk_size,
+        chunk_compression=chunk_compression,
+        overwrite=overwrite,
+    )
+
+
+def clip_event(
+    input_path: str | Path,
+    event_name: str,
+    output_path: str | Path | None = None,
+    before: float | None = None,
+    after: float | None = None,
+    include_topics: list[str] | None = None,
+    exclude_topics: list[str] | None = None,
+    chunk_size: int | None = None,
+    chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Clip an MCAP or bag file around an event."""
+    input_path = Path(input_path).resolve()
+    file_format = get_file_format_from_magic(input_path)
+
+    if file_format == "mcap":
+        return clip_event_mcap(
+            input_path,
+            event_name,
+            output_path=output_path,
+            before=before,
+            after=after,
+            include_topics=include_topics,
+            exclude_topics=exclude_topics,
+            chunk_size=chunk_size,
+            chunk_compression=chunk_compression,
+            overwrite=overwrite,
+        )
+    else:
+        raise ValueError("Events are not supported in bag format.")
+
+
+#####################
 # CLI Parser Setup  #
 #####################
 
@@ -490,6 +632,27 @@ def _run_delete(args) -> None:
     print(f"Events deleted. Output written to: {output_path}")
 
 
+def _run_clip(args) -> None:
+    """Run the event clip command."""
+    from pybag.cli.utils import validate_compression_for_mcap
+
+    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
+
+    output_path = clip_event(
+        args.input,
+        args.name,
+        output_path=args.output,
+        before=args.before,
+        after=args.after,
+        include_topics=args.include_topic,
+        exclude_topics=args.exclude_topic,
+        chunk_size=args.chunk_size,
+        chunk_compression=chunk_compression,
+        overwrite=args.overwrite,
+    )
+    print(f"Clipped around event '{args.name}'. Output written to: {output_path}")
+
+
 def add_parser(subparsers) -> None:
     """Add the event command and its subcommands to the argument parser."""
     event_parser = subparsers.add_parser(
@@ -507,6 +670,7 @@ def add_parser(subparsers) -> None:
               pybag event list <file>                - List all events
               pybag event add <file> <name> <time>   - Add a new event
               pybag event delete <file>              - Delete events
+              pybag event clip <file> <name>         - Clip MCAP around an event
 
             Note: Events are only supported in MCAP format, not bag files.
         """),
@@ -625,3 +789,66 @@ def add_parser(subparsers) -> None:
         help="Overwrite output file if it exists",
     )
     delete_parser.set_defaults(func=_run_delete)
+
+    # Clip subcommand
+    clip_parser = event_subparsers.add_parser(
+        "clip",
+        help="Extract a portion of an MCAP file around an event.",
+        description=dedent("""
+            Clip an MCAP file around an event, extracting messages within a time
+            window centered on the event's timestamp. This is useful for extracting
+            specific incidents or occurrences from a larger recording.
+
+            By default, if only --before or --after is specified, the other uses
+            the same value (symmetric clipping). If neither is specified, both
+            default to 5 seconds.
+
+            Example:
+              pybag event clip recording.mcap "collision" --before 5 --after 10
+              pybag event clip recording.mcap "start" --before 2
+              pybag event clip recording.mcap "incident" -o incident.mcap
+        """),
+    )
+    clip_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
+    clip_parser.add_argument("name", help="Name of the event to clip around")
+    clip_parser.add_argument(
+        "-o", "--output",
+        help="Output file path. If not specified, creates <input>_clip_<event_name>.mcap",
+    )
+    clip_parser.add_argument(
+        "--before",
+        type=float,
+        help="Time in seconds to include before the event (default: 5.0, or same as --after)",
+    )
+    clip_parser.add_argument(
+        "--after",
+        type=float,
+        help="Time in seconds to include after the event (default: 5.0, or same as --before)",
+    )
+    clip_parser.add_argument(
+        "--include-topic",
+        action="append",
+        help="Topics to include (supports glob patterns). Can be used multiple times.",
+    )
+    clip_parser.add_argument(
+        "--exclude-topic",
+        action="append",
+        help="Topics to exclude (supports glob patterns). Can be used multiple times.",
+    )
+    clip_parser.add_argument(
+        "--chunk-size",
+        type=int,
+        help="Chunk size of the output file in bytes",
+    )
+    clip_parser.add_argument(
+        "--chunk-compression",
+        type=str,
+        choices=["lz4", "zstd", "none"],
+        help="Compression used for chunk records",
+    )
+    clip_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite output file if it exists",
+    )
+    clip_parser.set_defaults(func=_run_clip)

--- a/src/pybag/cli/event.py
+++ b/src/pybag/cli/event.py
@@ -64,13 +64,23 @@ def _get_event_description(metadata: MetadataRecord) -> str | None:
     return metadata.metadata.get("description")
 
 
+def _is_event_deleted(metadata: MetadataRecord) -> bool:
+    """Check if an event is marked as deleted."""
+    return metadata.metadata.get("deleted", "").lower() == "true"
+
+
 def _event_matches_filters(
     metadata: MetadataRecord,
     name: str | None = None,
     start_time_ns: int | None = None,
     end_time_ns: int | None = None,
+    include_deleted: bool = False,
 ) -> bool:
     """Check if an event matches the given filters."""
+    # Filter out deleted events unless explicitly included
+    if not include_deleted and _is_event_deleted(metadata):
+        return False
+
     if name is not None:
         event_name = _get_event_name(metadata)
         if event_name != name:
@@ -130,12 +140,36 @@ def _event_to_json(event: MetadataRecord) -> dict:
     if description:
         result["description"] = description
 
+    # Include deleted status if the event is deleted
+    if _is_event_deleted(event):
+        result["deleted"] = True
+
     # Add any extra custom fields
     for key, value in event.metadata.items():
-        if key not in ("timestamp", "name", "description"):
+        if key not in ("timestamp", "name", "description", "deleted"):
             result[key] = value
 
     return result
+
+
+def _get_event_identity(metadata: MetadataRecord) -> tuple[int | None, str]:
+    """Get the unique identity of an event (timestamp, name)."""
+    return (_get_event_timestamp(metadata), _get_event_name(metadata))
+
+
+def _get_deleted_event_identities(
+    all_metadata: list[MetadataRecord],
+) -> set[tuple[int | None, str]]:
+    """Build a set of deleted event identities from metadata records.
+
+    Soft delete works by appending a copy of the event with deleted=true.
+    This function finds all events marked as deleted and returns their identities.
+    """
+    deleted_identities: set[tuple[int | None, str]] = set()
+    for metadata in all_metadata:
+        if _is_event_metadata(metadata) and _is_event_deleted(metadata):
+            deleted_identities.add(_get_event_identity(metadata))
+    return deleted_identities
 
 
 def list_events_mcap(
@@ -144,6 +178,7 @@ def list_events_mcap(
     name: str | None = None,
     start_time: float | None = None,
     end_time: float | None = None,
+    include_deleted: bool = False,
     output_json: bool = False,
 ) -> None:
     """List events in an MCAP file."""
@@ -153,11 +188,24 @@ def list_events_mcap(
     with McapRecordReaderFactory.from_file(input_path) as reader:
         all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
 
-        # Filter events
-        events = [
-            m for m in all_metadata
-            if _is_event_metadata(m) and _event_matches_filters(m, name, start_ns, end_ns)
-        ]
+        # Build set of deleted event identities for filtering
+        deleted_identities = _get_deleted_event_identities(all_metadata)
+
+        # Filter events - also check if event identity is in deleted set
+        events: list[MetadataRecord] = []
+        for m in all_metadata:
+            if not _is_event_metadata(m):
+                continue
+            # Skip records that are explicitly marked as deleted
+            if _is_event_deleted(m):
+                continue
+            # Skip events whose identity matches a deleted event (unless include_deleted)
+            if not include_deleted and _get_event_identity(m) in deleted_identities:
+                continue
+            # Apply other filters (name, time range)
+            if not _event_matches_filters(m, name, start_ns, end_ns, include_deleted=True):
+                continue
+            events.append(m)
 
         if output_json:
             print(json.dumps([_event_to_json(e) for e in events], indent=2))
@@ -172,6 +220,7 @@ def list_events(
     name: str | None = None,
     start_time: float | None = None,
     end_time: float | None = None,
+    include_deleted: bool = False,
     output_json: bool = False,
 ) -> None:
     """List events in an MCAP or bag file."""
@@ -184,6 +233,7 @@ def list_events(
             name=name,
             start_time=start_time,
             end_time=end_time,
+            include_deleted=include_deleted,
             output_json=output_json,
         )
     else:
@@ -282,7 +332,77 @@ def add_event(
 # Event Deletion    #
 #####################
 
-def delete_events_mcap(
+def soft_delete_events_mcap(
+    input_path: str | Path,
+    name: str | None = None,
+    start_time: float | None = None,
+    end_time: float | None = None,
+) -> tuple[Path, int]:
+    """Soft delete events by marking them with deleted=true.
+
+    This function appends new metadata records that mark matching events as
+    deleted without rewriting the entire file. The original event records
+    remain in the file but will be filtered out by default when listing.
+
+    Args:
+        input_path: Path to the MCAP file to modify.
+        name: Filter events to delete by name.
+        start_time: Filter events with timestamp >= start_time (seconds).
+        end_time: Filter events with timestamp <= end_time (seconds).
+
+    Returns:
+        Tuple of (path to modified file, number of events marked as deleted).
+    """
+    input_path = Path(input_path).resolve()
+    start_ns = _to_ns(start_time)
+    end_ns = _to_ns(end_time)
+
+    # Find events to delete
+    events_to_delete: list[MetadataRecord] = []
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        for metadata in all_metadata:
+            if _is_event_metadata(metadata) and _event_matches_filters(
+                metadata, name, start_ns, end_ns, include_deleted=False
+            ):
+                events_to_delete.append(metadata)
+
+    if not events_to_delete:
+        logger.warning("No events match the deletion criteria.")
+        return input_path, 0
+
+    # Load existing summary from the file using FileReader (for peek support)
+    summary = McapSummaryFactory.create_summary(
+        file=FileReader(input_path),
+        load_summary_eagerly=True,
+    )
+
+    # Open file for reading and writing (append mode)
+    file_writer = FileWriter(input_path, mode="r+b")
+
+    # Create writer in append mode
+    with McapRecordWriterFactory.create_writer(
+        file_writer,
+        summary,
+        mode='a',
+        chunk_size=1024 * 1024,
+    ) as writer:
+        # Write new metadata records marking events as deleted
+        for event in events_to_delete:
+            # Copy existing metadata and add deleted flag
+            deleted_metadata = dict(event.metadata)
+            deleted_metadata["deleted"] = "true"
+            deleted_event = MetadataRecord(
+                name=EVENT_METADATA_NAME,
+                metadata=deleted_metadata,
+            )
+            writer.write_metadata(deleted_event)
+
+    logger.info(f"Soft deleted {len(events_to_delete)} event(s).")
+    return input_path, len(events_to_delete)
+
+
+def hard_delete_events_mcap(
     input_path: str | Path,
     output_path: str | Path | None = None,
     name: str | None = None,
@@ -413,14 +533,37 @@ def delete_events(
     chunk_size: int | None = None,
     chunk_compression: Literal["none", "lz4", "zstd"] | None = None,
     *,
+    force: bool = False,
     overwrite: bool = False,
-) -> Path:
-    """Delete events from an MCAP or bag file."""
+) -> tuple[Path, int]:
+    """Delete events from an MCAP or bag file.
+
+    By default, performs a soft delete by marking events with deleted=true.
+    Use force=True to perform a hard delete that rewrites the file.
+
+    Args:
+        input_path: Path to input file.
+        output_path: Path to output file (only used for hard delete).
+        name: Filter events to delete by name.
+        start_time: Filter events with timestamp >= start_time (seconds).
+        end_time: Filter events with timestamp <= end_time (seconds).
+        chunk_size: Target chunk size for output (only used for hard delete).
+        chunk_compression: Compression algorithm (only used for hard delete).
+        force: If True, performs hard delete (rewrites file). Default is soft delete.
+        overwrite: Whether to overwrite output file if it exists.
+
+    Returns:
+        Tuple of (path to output file, number of events deleted).
+    """
     input_path = Path(input_path).resolve()
     file_format = get_file_format_from_magic(input_path)
 
-    if file_format == "mcap":
-        return delete_events_mcap(
+    if file_format != "mcap":
+        raise ValueError("Events are not supported in bag format.")
+
+    if force:
+        # Hard delete: rewrite the file without matching events
+        result_path = hard_delete_events_mcap(
             input_path,
             output_path=output_path,
             name=name,
@@ -430,8 +573,17 @@ def delete_events(
             chunk_compression=chunk_compression,
             overwrite=overwrite,
         )
+        # Count deleted events for return value
+        # (hard_delete_events_mcap logs but doesn't return count)
+        return result_path, -1  # -1 indicates count not available
     else:
-        raise ValueError("Events are not supported in bag format.")
+        # Soft delete: mark events as deleted without rewriting
+        return soft_delete_events_mcap(
+            input_path,
+            name=name,
+            start_time=start_time,
+            end_time=end_time,
+        )
 
 
 #####################
@@ -442,9 +594,8 @@ def clip_event_mcap(
     input_path: str | Path,
     event_name: str,
     output_path: str | Path | None = None,
-    before: float | None = None,
-    after: float | None = None,
-    margin: float | None = None,
+    before: float = 5.0,
+    after: float = 5.0,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -462,12 +613,10 @@ def clip_event_mcap(
         event_name: Name of the event to clip around.
         output_path: Path to output MCAP file. If None, defaults to
             <input_stem>_clip_<event_name>.mcap.
-        before: Time in seconds to include before the event. If specified
-            without --after, clips from (event_time - before) to event_time.
-        after: Time in seconds to include after the event. If specified
-            without --before, clips from event_time to (event_time + after).
-        margin: Symmetric margin - time in seconds to include both before
-            and after the event. Equivalent to --before X --after X.
+        before: Time in seconds to include before the event. Clips from
+            (event_time - before) to (event_time + after). Default: 5.0.
+        after: Time in seconds to include after the event. Clips from
+            (event_time - before) to (event_time + after). Default: 5.0.
         include_topics: List of topic patterns to include (glob patterns supported).
             If None, all topics are included.
         exclude_topics: List of topic patterns to exclude (glob patterns supported).
@@ -479,36 +628,26 @@ def clip_event_mcap(
         Path to the output MCAP file.
 
     Raises:
-        ValueError: If no event with the given name is found, if conflicting
-            options are specified, or if no time range is specified.
+        ValueError: If no event with the given name is found.
     """
     from pybag.cli.filter import filter_mcap
 
     input_path = Path(input_path).resolve()
 
-    # Validate options
-    if margin is not None and (before is not None or after is not None):
-        raise ValueError("Cannot use --margin together with --before or --after")
-
-    # Determine time margins
-    if margin is not None:
-        before_margin = margin
-        after_margin = margin
-    elif before is None and after is None:
-        # Default to 5s margin if nothing specified
-        before_margin = 5.0
-        after_margin = 5.0
-    else:
-        # Use 0 for unspecified values (clip up to or from event time)
-        before_margin = before if before is not None else 0.0
-        after_margin = after if after is not None else 0.0
-
-    # Find the event
+    # Find the event (excluding soft-deleted events)
     with McapRecordReaderFactory.from_file(input_path) as reader:
         all_metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+
+        # Build set of deleted event identities
+        deleted_identities = _get_deleted_event_identities(all_metadata)
+
+        # Find matching non-deleted events
         matching_events = [
             m for m in all_metadata
-            if _is_event_metadata(m) and _get_event_name(m) == event_name
+            if _is_event_metadata(m)
+            and _get_event_name(m) == event_name
+            and not _is_event_deleted(m)
+            and _get_event_identity(m) not in deleted_identities
         ]
 
         if not matching_events:
@@ -529,8 +668,8 @@ def clip_event_mcap(
     event_timestamp_s = _ns_to_seconds(event_timestamp_ns)
 
     # Calculate clip time range
-    start_time = event_timestamp_s - before_margin
-    end_time = event_timestamp_s + after_margin
+    start_time = event_timestamp_s - before
+    end_time = event_timestamp_s + after
 
     # Default output path
     if output_path is None:
@@ -555,9 +694,8 @@ def clip_event(
     input_path: str | Path,
     event_name: str,
     output_path: str | Path | None = None,
-    before: float | None = None,
-    after: float | None = None,
-    margin: float | None = None,
+    before: float = 5.0,
+    after: float = 5.0,
     include_topics: list[str] | None = None,
     exclude_topics: list[str] | None = None,
     chunk_size: int | None = None,
@@ -576,7 +714,6 @@ def clip_event(
             output_path=output_path,
             before=before,
             after=after,
-            margin=margin,
             include_topics=include_topics,
             exclude_topics=exclude_topics,
             chunk_size=chunk_size,
@@ -598,6 +735,7 @@ def _run_list(args) -> None:
         name=args.name,
         start_time=args.start_time,
         end_time=args.end_time,
+        include_deleted=getattr(args, 'include_deleted', False),
         output_json=args.output_json,
     )
 
@@ -628,19 +766,36 @@ def _run_delete(args) -> None:
     """Run the event delete command."""
     from pybag.cli.utils import validate_compression_for_mcap
 
-    chunk_compression = validate_compression_for_mcap(args.chunk_compression)
+    force = getattr(args, 'force', False)
 
-    output_path = delete_events(
-        args.input,
-        output_path=args.output,
-        name=args.name,
-        start_time=args.start_time,
-        end_time=args.end_time,
-        chunk_size=args.chunk_size,
-        chunk_compression=chunk_compression,
-        overwrite=args.overwrite,
-    )
-    print(f"Events deleted. Output written to: {output_path}")
+    if force:
+        # Hard delete requires output path
+        chunk_compression = validate_compression_for_mcap(args.chunk_compression)
+        output_path, _ = delete_events(
+            args.input,
+            output_path=args.output,
+            name=args.name,
+            start_time=args.start_time,
+            end_time=args.end_time,
+            chunk_size=args.chunk_size,
+            chunk_compression=chunk_compression,
+            force=True,
+            overwrite=args.overwrite,
+        )
+        print(f"Events deleted. Output written to: {output_path}")
+    else:
+        # Soft delete modifies in place
+        output_path, count = delete_events(
+            args.input,
+            name=args.name,
+            start_time=args.start_time,
+            end_time=args.end_time,
+            force=False,
+        )
+        if count == 0:
+            print("No events matched the deletion criteria.")
+        else:
+            print(f"Marked {count} event(s) as deleted in: {output_path}")
 
 
 def _run_clip(args) -> None:
@@ -649,13 +804,27 @@ def _run_clip(args) -> None:
 
     chunk_compression = validate_compression_for_mcap(args.chunk_compression)
 
+    # Handle --margin flag: it's a CLI convenience that sets both before and after
+    if args.margin is not None:
+        if args.before is not None or args.after is not None:
+            raise ValueError("Cannot use --margin together with --before or --after")
+        before = args.margin
+        after = args.margin
+    elif args.before is None and args.after is None:
+        # Default to 5s margin if nothing specified
+        before = 5.0
+        after = 5.0
+    else:
+        # Use 0 for unspecified values (clip up to or from event time)
+        before = args.before if args.before is not None else 0.0
+        after = args.after if args.after is not None else 0.0
+
     output_path = clip_event(
         args.input,
         args.name,
         output_path=args.output,
-        before=args.before,
-        after=args.after,
-        margin=args.margin,
+        before=before,
+        after=after,
         include_topics=args.include_topic,
         exclude_topics=args.exclude_topic,
         chunk_size=args.chunk_size,
@@ -717,6 +886,12 @@ def add_parser(subparsers) -> None:
         dest="output_json",
         help="Output in JSON format",
     )
+    list_parser.add_argument(
+        "--include-deleted",
+        action="store_true",
+        dest="include_deleted",
+        help="Include events that have been soft deleted",
+    )
     list_parser.set_defaults(func=_run_list)
 
     # Add subcommand
@@ -760,15 +935,23 @@ def add_parser(subparsers) -> None:
             Delete events from an MCAP file. Use filters to select which events
             to delete. If no filters are provided, all events will be deleted.
 
+            By default, events are soft deleted by marking them with a "deleted"
+            flag. This modifies the file in place without rewriting it. Soft
+            deleted events are hidden from listing by default but can be shown
+            with --include-deleted.
+
+            Use --force to perform a hard delete that rewrites the file without
+            the deleted events. This creates a new output file.
+
             Example:
-              pybag event delete recording.mcap --name "collision"
-              pybag event delete recording.mcap --start-time 5.0 --end-time 10.0
+              pybag event delete recording.mcap --name "collision"  # soft delete
+              pybag event delete recording.mcap --force -o clean.mcap  # hard delete
         """),
     )
     delete_parser.add_argument("input", help="Path to input MCAP file (*.mcap)")
     delete_parser.add_argument(
         "-o", "--output",
-        help="Output file path. If not specified, creates <input>_filtered.mcap",
+        help="Output file path (only used with --force). Defaults to <input>_filtered.mcap",
     )
     delete_parser.add_argument(
         "--name",
@@ -785,20 +968,25 @@ def add_parser(subparsers) -> None:
         help="Delete events with timestamp <= end_time (in seconds)",
     )
     delete_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Hard delete: rewrite the file without deleted events (creates new file)",
+    )
+    delete_parser.add_argument(
         "--chunk-size",
         type=int,
-        help="Chunk size of the output file in bytes",
+        help="Chunk size of the output file in bytes (only used with --force)",
     )
     delete_parser.add_argument(
         "--chunk-compression",
         type=str,
         choices=["lz4", "zstd", "none"],
-        help="Compression used for chunk records",
+        help="Compression used for chunk records (only used with --force)",
     )
     delete_parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Overwrite output file if it exists",
+        help="Overwrite output file if it exists (only used with --force)",
     )
     delete_parser.set_defaults(func=_run_delete)
 

--- a/src/pybag/cli/main.py
+++ b/src/pybag/cli/main.py
@@ -1,6 +1,6 @@
 import argparse
 
-from pybag.cli import convert, filter, info, inspect, merge, recover, sort
+from pybag.cli import convert, event, filter, info, inspect, merge, recover, sort
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -18,6 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # TODO: Have some of entrypoint registration?
     convert.add_parser(subparsers)
+    event.add_parser(subparsers)
     filter.add_parser(subparsers)
     info.add_parser(subparsers)
     inspect.add_parser(subparsers)

--- a/src/pybag/cli/main.py
+++ b/src/pybag/cli/main.py
@@ -1,6 +1,15 @@
 import argparse
 
-from pybag.cli import convert, event, filter, info, inspect, merge, recover, sort
+from pybag.cli import (
+    convert,
+    event,
+    filter,
+    info,
+    inspect,
+    merge,
+    recover,
+    sort
+)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -1,6 +1,5 @@
 """Tests for the event CLI command."""
 
-import shutil
 from pathlib import Path
 
 import pytest

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -121,6 +121,38 @@ def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
         assert "end" in names
 
 
+def test_cli_event_add_with_output(tmp_path: Path) -> None:
+    """Test adding an event with -o flag copies MCAP and adds event to copy."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_message("/foo", int(2e9), Int32(data=2))
+
+    # Add event with -o flag (copy mode)
+    cli_main([
+        "event", "add", str(input_path),
+        "test_event", "1.5",
+        "-o", str(output_path),
+    ])
+
+    # Verify original file is unchanged (no events)
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 0
+
+    # Verify output file has the event and messages
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+        assert metadata[0].metadata["name"] == "test_event"
+
+        # Verify messages are copied
+        messages = list(reader.get_messages())
+        assert len(messages) == 2
+
+
 def test_cli_event_soft_delete(tmp_path: Path) -> None:
     """Test soft delete (default) marks events as deleted."""
     input_path = tmp_path / "input.mcap"
@@ -208,7 +240,7 @@ def test_cli_event_list_include_deleted(tmp_path: Path, capsys) -> None:
 
 
 def test_cli_event_hard_delete_all(tmp_path: Path) -> None:
-    """Test hard delete (--force) removes all events from file."""
+    """Test hard delete (-o) removes all events from file."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -222,10 +254,9 @@ def test_cli_event_hard_delete_all(tmp_path: Path) -> None:
         "event1", "1.0",
     ])
 
-    # Hard delete all events
+    # Hard delete all events (using -o triggers hard delete)
     cli_main([
         "event", "delete", str(input_path),
-        "--force",
         "-o", str(output_path),
     ])
 
@@ -254,11 +285,10 @@ def test_cli_event_hard_delete_by_name(tmp_path: Path) -> None:
         "collision", "5.0",
     ])
 
-    # Hard delete only "collision" events
+    # Hard delete only "collision" events (using -o triggers hard delete)
     cli_main([
         "event", "delete", str(input_path),
         "--name", "collision",
-        "--force",
         "-o", str(output_path),
     ])
 
@@ -290,12 +320,11 @@ def test_cli_event_hard_delete_by_time_range(tmp_path: Path) -> None:
         "event3", "10.0",
     ])
 
-    # Hard delete events between 4s and 6s
+    # Hard delete events between 4s and 6s (using -o triggers hard delete)
     cli_main([
         "event", "delete", str(input_path),
         "--start-time", "4.0",
         "--end-time", "6.0",
-        "--force",
         "-o", str(output_path),
     ])
 
@@ -455,10 +484,9 @@ def test_cli_event_hard_delete_preserves_non_event_metadata(tmp_path: Path) -> N
         "test_event", "1.0",
     ])
 
-    # Hard delete all events
+    # Hard delete all events (using -o triggers hard delete)
     cli_main([
         "event", "delete", str(input_path),
-        "--force",
         "-o", str(output_path),
     ])
 

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -121,8 +121,94 @@ def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
         assert "end" in names
 
 
-def test_cli_event_delete_all(tmp_path: Path) -> None:
-    """Test deleting all events."""
+def test_cli_event_soft_delete(tmp_path: Path) -> None:
+    """Test soft delete (default) marks events as deleted."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add an event
+    cli_main([
+        "event", "add", str(input_path),
+        "event1", "1.0",
+    ])
+
+    # Soft delete (default, no --force)
+    cli_main([
+        "event", "delete", str(input_path),
+        "--name", "event1",
+    ])
+
+    # The event record should still exist but be marked as deleted
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        all_events = reader.get_metadata(name=EVENT_METADATA_NAME)
+        # Original + deleted version
+        assert len(all_events) == 2
+        # The deleted version has deleted=true
+        deleted_events = [e for e in all_events if e.metadata.get("deleted") == "true"]
+        assert len(deleted_events) == 1
+
+
+def test_cli_event_soft_delete_hidden_from_list(tmp_path: Path, capsys) -> None:
+    """Test that soft deleted events are hidden from list by default."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "visible", "1.0",
+    ])
+    cli_main([
+        "event", "add", str(input_path),
+        "to_delete", "2.0",
+    ])
+
+    # Soft delete one event
+    cli_main([
+        "event", "delete", str(input_path),
+        "--name", "to_delete",
+    ])
+
+    capsys.readouterr()
+
+    # List should only show the visible event
+    cli_main(["event", "list", str(input_path)])
+    captured = capsys.readouterr()
+    assert "visible" in captured.out
+    assert "to_delete" not in captured.out
+
+
+def test_cli_event_list_include_deleted(tmp_path: Path, capsys) -> None:
+    """Test that --include-deleted shows soft deleted events."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "event1", "1.0",
+    ])
+
+    # Soft delete
+    cli_main([
+        "event", "delete", str(input_path),
+        "--name", "event1",
+    ])
+
+    capsys.readouterr()
+
+    # List with --include-deleted should show the event
+    cli_main(["event", "list", str(input_path), "--include-deleted"])
+    captured = capsys.readouterr()
+    assert "event1" in captured.out
+
+
+def test_cli_event_hard_delete_all(tmp_path: Path) -> None:
+    """Test hard delete (--force) removes all events from file."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -136,9 +222,10 @@ def test_cli_event_delete_all(tmp_path: Path) -> None:
         "event1", "1.0",
     ])
 
-    # Delete all events
+    # Hard delete all events
     cli_main([
         "event", "delete", str(input_path),
+        "--force",
         "-o", str(output_path),
     ])
 
@@ -147,8 +234,8 @@ def test_cli_event_delete_all(tmp_path: Path) -> None:
         assert len(metadata) == 0
 
 
-def test_cli_event_delete_by_name(tmp_path: Path) -> None:
-    """Test deleting events by name."""
+def test_cli_event_hard_delete_by_name(tmp_path: Path) -> None:
+    """Test hard deleting events by name."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -167,10 +254,11 @@ def test_cli_event_delete_by_name(tmp_path: Path) -> None:
         "collision", "5.0",
     ])
 
-    # Delete only "collision" events
+    # Hard delete only "collision" events
     cli_main([
         "event", "delete", str(input_path),
         "--name", "collision",
+        "--force",
         "-o", str(output_path),
     ])
 
@@ -180,8 +268,8 @@ def test_cli_event_delete_by_name(tmp_path: Path) -> None:
         assert metadata[0].metadata["name"] == "start"
 
 
-def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
-    """Test deleting events by time range."""
+def test_cli_event_hard_delete_by_time_range(tmp_path: Path) -> None:
+    """Test hard deleting events by time range."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -202,11 +290,12 @@ def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
         "event3", "10.0",
     ])
 
-    # Delete events between 4s and 6s
+    # Hard delete events between 4s and 6s
     cli_main([
         "event", "delete", str(input_path),
         "--start-time", "4.0",
         "--end-time", "6.0",
+        "--force",
         "-o", str(output_path),
     ])
 
@@ -351,8 +440,8 @@ def test_cli_event_bag_not_supported(tmp_path: Path, capsys) -> None:
         ])
 
 
-def test_cli_event_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
-    """Test that deleting events preserves non-event metadata."""
+def test_cli_event_hard_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
+    """Test that hard deleting events preserves non-event metadata."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -366,9 +455,10 @@ def test_cli_event_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
         "test_event", "1.0",
     ])
 
-    # Delete all events
+    # Hard delete all events
     cli_main([
         "event", "delete", str(input_path),
+        "--force",
         "-o", str(output_path),
     ])
 

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -421,8 +421,8 @@ def test_cli_event_clip_basic(tmp_path: Path) -> None:
         assert max(timestamps) <= 13.0
 
 
-def test_cli_event_clip_symmetric_single_arg(tmp_path: Path) -> None:
-    """Test that clip uses symmetric margin when only --before is given."""
+def test_cli_event_clip_before_only(tmp_path: Path) -> None:
+    """Test that --before clips from (event_time - before) to event_time."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -435,7 +435,7 @@ def test_cli_event_clip_symmetric_single_arg(tmp_path: Path) -> None:
         "incident", "10.0",
     ])
 
-    # Only specify --before, should use same value for after
+    # Only specify --before, should clip from 8s to 10s
     cli_main([
         "event", "clip", str(input_path),
         "incident",
@@ -447,14 +447,14 @@ def test_cli_event_clip_symmetric_single_arg(tmp_path: Path) -> None:
         messages = list(reader.get_messages())
         timestamps = [m.log_time / 1e9 for m in messages]
 
-        # Should have messages at 8, 9, 10, 11, 12 = 5 messages
-        assert len(messages) == 5
+        # Should have messages at 8, 9, 10 = 3 messages
+        assert len(messages) == 3
         assert min(timestamps) >= 8.0
-        assert max(timestamps) <= 12.0
+        assert max(timestamps) <= 10.0
 
 
-def test_cli_event_clip_symmetric_after_only(tmp_path: Path) -> None:
-    """Test that clip uses symmetric margin when only --after is given."""
+def test_cli_event_clip_after_only(tmp_path: Path) -> None:
+    """Test that --after clips from event_time to (event_time + after)."""
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
 
@@ -467,11 +467,43 @@ def test_cli_event_clip_symmetric_after_only(tmp_path: Path) -> None:
         "incident", "10.0",
     ])
 
-    # Only specify --after, should use same value for before
+    # Only specify --after, should clip from 10s to 12s
     cli_main([
         "event", "clip", str(input_path),
         "incident",
         "--after", "2",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 10, 11, 12 = 3 messages
+        assert len(messages) == 3
+        assert min(timestamps) >= 10.0
+        assert max(timestamps) <= 12.0
+
+
+def test_cli_event_clip_margin(tmp_path: Path) -> None:
+    """Test that --margin clips symmetrically before and after."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # Specify --margin for symmetric clipping
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--margin", "2",
         "-o", str(output_path),
     ])
 
@@ -560,6 +592,27 @@ def test_cli_event_clip_event_not_found(tmp_path: Path) -> None:
         cli_main([
             "event", "clip", str(input_path),
             "nonexistent",
+        ])
+
+
+def test_cli_event_clip_margin_with_before_error(tmp_path: Path) -> None:
+    """Test that --margin cannot be used with --before."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "1.0",
+    ])
+
+    with pytest.raises(ValueError, match="Cannot use --margin together with"):
+        cli_main([
+            "event", "clip", str(input_path),
+            "incident",
+            "--margin", "5",
+            "--before", "2",
         ])
 
 

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -1,0 +1,427 @@
+"""Tests for the event CLI command."""
+
+from pathlib import Path
+
+import pytest
+
+from pybag.cli.event import EVENT_METADATA_NAME
+from pybag.cli.main import main as cli_main
+from pybag.mcap.record_reader import McapRecordReaderFactory
+from pybag.mcap_writer import McapFileWriter
+from pybag.ros2.humble.std_msgs import Int32
+
+
+def test_cli_event_list_empty(tmp_path: Path) -> None:
+    """Test listing events when there are none."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # List events (should be empty)
+    cli_main(["event", "list", str(input_path)])
+
+
+def test_cli_event_add_and_list(tmp_path: Path) -> None:
+    """Test adding an event and listing it."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_message("/foo", int(2e9), Int32(data=2))
+
+    # Add an event
+    cli_main([
+        "event", "add", str(input_path),
+        "start", "1.5",
+        "-o", str(output_path),
+    ])
+
+    # Verify event was added
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+        assert metadata[0].metadata["name"] == "start"
+        assert metadata[0].metadata["timestamp"] == str(int(1.5e9))
+
+        # Verify messages are preserved
+        channels = reader.get_channels()
+        assert len(channels) == 1
+
+
+def test_cli_event_add_with_description(tmp_path: Path) -> None:
+    """Test adding an event with description."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add event with description
+    cli_main([
+        "event", "add", str(input_path),
+        "collision", "5.0",
+        "--description", "Hit obstacle at corner",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+        assert metadata[0].metadata["name"] == "collision"
+        assert metadata[0].metadata["description"] == "Hit obstacle at corner"
+
+
+def test_cli_event_add_with_extra_fields(tmp_path: Path) -> None:
+    """Test adding an event with extra key-value pairs."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add event with extra fields
+    cli_main([
+        "event", "add", str(input_path),
+        "waypoint", "10.0",
+        "--extra", "waypoint_id=42",
+        "--extra", "location=entrance",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+        assert metadata[0].metadata["name"] == "waypoint"
+        assert metadata[0].metadata["waypoint_id"] == "42"
+        assert metadata[0].metadata["location"] == "entrance"
+
+
+def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
+    """Test adding multiple events."""
+    input_path = tmp_path / "input.mcap"
+    output1_path = tmp_path / "output1.mcap"
+    output2_path = tmp_path / "output2.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_message("/foo", int(5e9), Int32(data=2))
+        writer.write_message("/foo", int(10e9), Int32(data=3))
+
+    # Add first event
+    cli_main([
+        "event", "add", str(input_path),
+        "start", "0.0",
+        "-o", str(output1_path),
+    ])
+
+    # Add second event to the output
+    cli_main([
+        "event", "add", str(output1_path),
+        "end", "10.0",
+        "-o", str(output2_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output2_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 2
+        names = [m.metadata["name"] for m in metadata]
+        assert "start" in names
+        assert "end" in names
+
+
+def test_cli_event_delete_all(tmp_path: Path) -> None:
+    """Test deleting all events."""
+    input_path = tmp_path / "input.mcap"
+    with_events_path = tmp_path / "with_events.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    # Create MCAP with messages
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add events
+    cli_main([
+        "event", "add", str(input_path),
+        "event1", "1.0",
+        "-o", str(with_events_path),
+    ])
+
+    # Delete all events
+    cli_main([
+        "event", "delete", str(with_events_path),
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 0
+
+
+def test_cli_event_delete_by_name(tmp_path: Path) -> None:
+    """Test deleting events by name."""
+    input_path = tmp_path / "input.mcap"
+    with_events_path = tmp_path / "with_events.mcap"
+    with_events2_path = tmp_path / "with_events2.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add first event
+    cli_main([
+        "event", "add", str(input_path),
+        "start", "1.0",
+        "-o", str(with_events_path),
+    ])
+
+    # Add second event
+    cli_main([
+        "event", "add", str(with_events_path),
+        "collision", "5.0",
+        "-o", str(with_events2_path),
+    ])
+
+    # Delete only "collision" events
+    cli_main([
+        "event", "delete", str(with_events2_path),
+        "--name", "collision",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+        assert metadata[0].metadata["name"] == "start"
+
+
+def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
+    """Test deleting events by time range."""
+    input_path = tmp_path / "input.mcap"
+    with_events_path = tmp_path / "with_events.mcap"
+    with_events2_path = tmp_path / "with_events2.mcap"
+    with_events3_path = tmp_path / "with_events3.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Add events at different times
+    cli_main([
+        "event", "add", str(input_path),
+        "event1", "1.0",
+        "-o", str(with_events_path),
+    ])
+    cli_main([
+        "event", "add", str(with_events_path),
+        "event2", "5.0",
+        "-o", str(with_events2_path),
+    ])
+    cli_main([
+        "event", "add", str(with_events2_path),
+        "event3", "10.0",
+        "-o", str(with_events3_path),
+    ])
+
+    # Delete events between 4s and 6s
+    cli_main([
+        "event", "delete", str(with_events3_path),
+        "--start-time", "4.0",
+        "--end-time", "6.0",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 2
+        names = [m.metadata["name"] for m in metadata]
+        assert "event1" in names
+        assert "event3" in names
+        assert "event2" not in names
+
+
+def test_cli_event_list_filter_by_name(tmp_path: Path, capsys) -> None:
+    """Test listing events filtered by name."""
+    input_path = tmp_path / "input.mcap"
+    with_events_path = tmp_path / "with_events.mcap"
+    with_events2_path = tmp_path / "with_events2.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "start", "1.0",
+        "-o", str(with_events_path),
+    ])
+    cli_main([
+        "event", "add", str(with_events_path),
+        "collision", "5.0",
+        "-o", str(with_events2_path),
+    ])
+
+    # List only "collision" events
+    cli_main([
+        "event", "list", str(with_events2_path),
+        "--name", "collision",
+    ])
+
+    captured = capsys.readouterr()
+    assert "collision" in captured.out
+    assert "start" not in captured.out or "start" in captured.out.split("collision")[0]  # Should not be in data rows
+
+
+def test_cli_event_list_json_output(tmp_path: Path, capsys) -> None:
+    """Test listing events in JSON format."""
+    import json
+
+    input_path = tmp_path / "input.mcap"
+    with_events_path = tmp_path / "with_events.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "test_event", "2.5",
+        "--description", "Test description",
+        "-o", str(with_events_path),
+    ])
+
+    # Clear captured output from the add command
+    capsys.readouterr()
+
+    cli_main([
+        "event", "list", str(with_events_path),
+        "--json",
+    ])
+
+    captured = capsys.readouterr()
+    # The JSON output should be the entire output when --json is used
+    events = json.loads(captured.out.strip())
+    assert len(events) == 1
+    assert events[0]["name"] == "test_event"
+    assert events[0]["timestamp"] == int(2.5e9)
+    assert events[0]["description"] == "Test description"
+
+
+def test_cli_event_preserves_messages(tmp_path: Path) -> None:
+    """Test that adding events preserves all messages."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_message("/bar", int(2e9), Int32(data=2))
+        writer.write_message("/foo", int(3e9), Int32(data=3))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "test", "1.5",
+        "-o", str(output_path),
+    ])
+
+    # Verify all messages are preserved
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        channels = reader.get_channels()
+        assert len(channels) == 2
+
+        messages = list(reader.get_messages())
+        assert len(messages) == 3
+
+
+def test_cli_event_preserves_attachments_and_metadata(tmp_path: Path) -> None:
+    """Test that adding events preserves attachments and other metadata."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_attachment("test.txt", b"test data", "text/plain")
+        writer.write_metadata("config", {"key": "value"})
+
+    cli_main([
+        "event", "add", str(input_path),
+        "test", "1.0",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        attachments = reader.get_attachments()
+        assert len(attachments) == 1
+        assert attachments[0].name == "test.txt"
+
+        all_metadata = reader.get_metadata()
+        # Should have config + event
+        assert len(all_metadata) == 2
+
+
+def test_cli_event_add_overwrite(tmp_path: Path) -> None:
+    """Test overwrite flag for event add."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    # Create output file
+    output_path.touch()
+
+    # Without overwrite, should fail
+    with pytest.raises(ValueError, match="Output mcap exists"):
+        cli_main([
+            "event", "add", str(input_path),
+            "test", "1.0",
+            "-o", str(output_path),
+        ])
+
+    # With overwrite, should succeed
+    cli_main([
+        "event", "add", str(input_path),
+        "test", "1.0",
+        "-o", str(output_path),
+        "--overwrite",
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(metadata) == 1
+
+
+def test_cli_event_add_same_input_output_error(tmp_path: Path) -> None:
+    """Test that adding event with same input/output path raises error."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    with pytest.raises(ValueError, match="Input path cannot be same as output"):
+        cli_main([
+            "event", "add", str(input_path),
+            "test", "1.0",
+            "-o", str(input_path),
+        ])
+
+
+def test_cli_event_bag_not_supported(tmp_path: Path, capsys) -> None:
+    """Test that events are not supported for bag files."""
+    from pybag.bag_writer import BagFileWriter
+    from pybag.ros1.noetic.std_msgs import Int32 as Ros1Int32
+
+    input_path = tmp_path / "input.bag"
+
+    with BagFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Ros1Int32(data=1))
+
+    # List should print message about not supported
+    cli_main(["event", "list", str(input_path)])
+    captured = capsys.readouterr()
+    assert "not supported" in captured.out.lower()
+
+    # Add should raise error
+    with pytest.raises(ValueError, match="not supported in bag"):
+        cli_main([
+            "event", "add", str(input_path),
+            "test", "1.0",
+        ])

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -379,3 +379,281 @@ def test_cli_event_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
         assert len(all_metadata) == 1
         assert all_metadata[0].name == "config"
         assert all_metadata[0].metadata["setting"] == "value"
+
+
+#####################
+# Clip Command Tests
+#####################
+
+def test_cli_event_clip_basic(tmp_path: Path) -> None:
+    """Test basic clip around an event."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    # Create MCAP with messages spread over time
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            # Messages at 0s, 1s, 2s, ..., 19s
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    # Add an event at 10s
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # Clip around the event with 3s before and after
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--before", "3",
+        "--after", "3",
+        "-o", str(output_path),
+    ])
+
+    # Verify clipped file contains messages from 7s to 13s
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 7, 8, 9, 10, 11, 12, 13 = 7 messages
+        assert len(messages) == 7
+        assert min(timestamps) >= 7.0
+        assert max(timestamps) <= 13.0
+
+
+def test_cli_event_clip_symmetric_single_arg(tmp_path: Path) -> None:
+    """Test that clip uses symmetric margin when only --before is given."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # Only specify --before, should use same value for after
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--before", "2",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 8, 9, 10, 11, 12 = 5 messages
+        assert len(messages) == 5
+        assert min(timestamps) >= 8.0
+        assert max(timestamps) <= 12.0
+
+
+def test_cli_event_clip_symmetric_after_only(tmp_path: Path) -> None:
+    """Test that clip uses symmetric margin when only --after is given."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # Only specify --after, should use same value for before
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--after", "2",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 8, 9, 10, 11, 12 = 5 messages
+        assert len(messages) == 5
+        assert min(timestamps) >= 8.0
+        assert max(timestamps) <= 12.0
+
+
+def test_cli_event_clip_default_margin(tmp_path: Path) -> None:
+    """Test that clip uses default 5s margin when no --before/--after given."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # No margin specified, should default to 5s before and after
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 = 11 messages
+        assert len(messages) == 11
+        assert min(timestamps) >= 5.0
+        assert max(timestamps) <= 15.0
+
+
+def test_cli_event_clip_asymmetric(tmp_path: Path) -> None:
+    """Test clip with different before and after values."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(20):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "10.0",
+    ])
+
+    # 2s before, 5s after
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--before", "2",
+        "--after", "5",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        messages = list(reader.get_messages())
+        timestamps = [m.log_time / 1e9 for m in messages]
+
+        # Should have messages at 8, 9, 10, 11, 12, 13, 14, 15 = 8 messages
+        assert len(messages) == 8
+        assert min(timestamps) >= 8.0
+        assert max(timestamps) <= 15.0
+
+
+def test_cli_event_clip_event_not_found(tmp_path: Path) -> None:
+    """Test that clip raises error when event not found."""
+    input_path = tmp_path / "input.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+
+    with pytest.raises(ValueError, match="No event found"):
+        cli_main([
+            "event", "clip", str(input_path),
+            "nonexistent",
+        ])
+
+
+def test_cli_event_clip_with_topic_filter(tmp_path: Path) -> None:
+    """Test clip with topic filtering."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(10):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+            writer.write_message("/bar", int(i * 1e9), Int32(data=i * 10))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "5.0",
+    ])
+
+    # Clip but only include /foo topic
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--before", "2",
+        "--after", "2",
+        "--include-topic", "/foo",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        channels = reader.get_channels()
+        # Should only have /foo channel
+        assert len(channels) == 1
+        topic_names = [ch.topic for ch in channels.values()]
+        assert "/foo" in topic_names
+        assert "/bar" not in topic_names
+
+
+def test_cli_event_clip_default_output_name(tmp_path: Path) -> None:
+    """Test that clip generates appropriate default output filename."""
+    input_path = tmp_path / "recording.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(10):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "collision", "5.0",
+    ])
+
+    # Don't specify output path
+    cli_main([
+        "event", "clip", str(input_path),
+        "collision",
+        "--before", "2",
+        "--after", "2",
+    ])
+
+    # Check that default output file was created
+    expected_output = tmp_path / "recording_clip_collision.mcap"
+    assert expected_output.exists()
+
+
+def test_cli_event_clip_preserves_metadata(tmp_path: Path) -> None:
+    """Test that clip preserves metadata and attachments within time range."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for i in range(10):
+            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+        writer.write_metadata("config", {"key": "value"})
+        # Attachment at 5s (within clip range of 3s-7s)
+        writer.write_attachment("test.txt", b"test data", "text/plain", log_time=int(5e9))
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "5.0",
+    ])
+
+    cli_main([
+        "event", "clip", str(input_path),
+        "incident",
+        "--before", "2",
+        "--after", "2",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        all_metadata = reader.get_metadata()
+        # Should have config + event metadata
+        assert len(all_metadata) == 2
+
+        attachments = reader.get_attachments()
+        assert len(attachments) == 1
+        assert attachments[0].name == "test.txt"

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -1,5 +1,6 @@
 """Tests for the event CLI command."""
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -25,21 +26,19 @@ def test_cli_event_list_empty(tmp_path: Path) -> None:
 def test_cli_event_add_and_list(tmp_path: Path) -> None:
     """Test adding an event and listing it."""
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
         writer.write_message("/foo", int(2e9), Int32(data=2))
 
-    # Add an event
+    # Add an event (modifies file in place)
     cli_main([
         "event", "add", str(input_path),
         "start", "1.5",
-        "-o", str(output_path),
     ])
 
     # Verify event was added
-    with McapRecordReaderFactory.from_file(output_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
         assert len(metadata) == 1
         assert metadata[0].metadata["name"] == "start"
@@ -53,7 +52,6 @@ def test_cli_event_add_and_list(tmp_path: Path) -> None:
 def test_cli_event_add_with_description(tmp_path: Path) -> None:
     """Test adding an event with description."""
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -63,10 +61,9 @@ def test_cli_event_add_with_description(tmp_path: Path) -> None:
         "event", "add", str(input_path),
         "collision", "5.0",
         "--description", "Hit obstacle at corner",
-        "-o", str(output_path),
     ])
 
-    with McapRecordReaderFactory.from_file(output_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
         assert len(metadata) == 1
         assert metadata[0].metadata["name"] == "collision"
@@ -76,7 +73,6 @@ def test_cli_event_add_with_description(tmp_path: Path) -> None:
 def test_cli_event_add_with_extra_fields(tmp_path: Path) -> None:
     """Test adding an event with extra key-value pairs."""
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -87,10 +83,9 @@ def test_cli_event_add_with_extra_fields(tmp_path: Path) -> None:
         "waypoint", "10.0",
         "--extra", "waypoint_id=42",
         "--extra", "location=entrance",
-        "-o", str(output_path),
     ])
 
-    with McapRecordReaderFactory.from_file(output_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
         assert len(metadata) == 1
         assert metadata[0].metadata["name"] == "waypoint"
@@ -101,8 +96,6 @@ def test_cli_event_add_with_extra_fields(tmp_path: Path) -> None:
 def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
     """Test adding multiple events."""
     input_path = tmp_path / "input.mcap"
-    output1_path = tmp_path / "output1.mcap"
-    output2_path = tmp_path / "output2.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -113,17 +106,15 @@ def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
     cli_main([
         "event", "add", str(input_path),
         "start", "0.0",
-        "-o", str(output1_path),
     ])
 
-    # Add second event to the output
+    # Add second event
     cli_main([
-        "event", "add", str(output1_path),
+        "event", "add", str(input_path),
         "end", "10.0",
-        "-o", str(output2_path),
     ])
 
-    with McapRecordReaderFactory.from_file(output2_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
         assert len(metadata) == 2
         names = [m.metadata["name"] for m in metadata]
@@ -134,23 +125,21 @@ def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
 def test_cli_event_delete_all(tmp_path: Path) -> None:
     """Test deleting all events."""
     input_path = tmp_path / "input.mcap"
-    with_events_path = tmp_path / "with_events.mcap"
     output_path = tmp_path / "output.mcap"
 
     # Create MCAP with messages
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
 
-    # Add events
+    # Add an event
     cli_main([
         "event", "add", str(input_path),
         "event1", "1.0",
-        "-o", str(with_events_path),
     ])
 
     # Delete all events
     cli_main([
-        "event", "delete", str(with_events_path),
+        "event", "delete", str(input_path),
         "-o", str(output_path),
     ])
 
@@ -162,8 +151,6 @@ def test_cli_event_delete_all(tmp_path: Path) -> None:
 def test_cli_event_delete_by_name(tmp_path: Path) -> None:
     """Test deleting events by name."""
     input_path = tmp_path / "input.mcap"
-    with_events_path = tmp_path / "with_events.mcap"
-    with_events2_path = tmp_path / "with_events2.mcap"
     output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
@@ -173,19 +160,17 @@ def test_cli_event_delete_by_name(tmp_path: Path) -> None:
     cli_main([
         "event", "add", str(input_path),
         "start", "1.0",
-        "-o", str(with_events_path),
     ])
 
     # Add second event
     cli_main([
-        "event", "add", str(with_events_path),
+        "event", "add", str(input_path),
         "collision", "5.0",
-        "-o", str(with_events2_path),
     ])
 
     # Delete only "collision" events
     cli_main([
-        "event", "delete", str(with_events2_path),
+        "event", "delete", str(input_path),
         "--name", "collision",
         "-o", str(output_path),
     ])
@@ -199,9 +184,6 @@ def test_cli_event_delete_by_name(tmp_path: Path) -> None:
 def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
     """Test deleting events by time range."""
     input_path = tmp_path / "input.mcap"
-    with_events_path = tmp_path / "with_events.mcap"
-    with_events2_path = tmp_path / "with_events2.mcap"
-    with_events3_path = tmp_path / "with_events3.mcap"
     output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
@@ -211,22 +193,19 @@ def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
     cli_main([
         "event", "add", str(input_path),
         "event1", "1.0",
-        "-o", str(with_events_path),
     ])
     cli_main([
-        "event", "add", str(with_events_path),
+        "event", "add", str(input_path),
         "event2", "5.0",
-        "-o", str(with_events2_path),
     ])
     cli_main([
-        "event", "add", str(with_events2_path),
+        "event", "add", str(input_path),
         "event3", "10.0",
-        "-o", str(with_events3_path),
     ])
 
     # Delete events between 4s and 6s
     cli_main([
-        "event", "delete", str(with_events3_path),
+        "event", "delete", str(input_path),
         "--start-time", "4.0",
         "--end-time", "6.0",
         "-o", str(output_path),
@@ -244,8 +223,6 @@ def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
 def test_cli_event_list_filter_by_name(tmp_path: Path, capsys) -> None:
     """Test listing events filtered by name."""
     input_path = tmp_path / "input.mcap"
-    with_events_path = tmp_path / "with_events.mcap"
-    with_events2_path = tmp_path / "with_events2.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -253,17 +230,18 @@ def test_cli_event_list_filter_by_name(tmp_path: Path, capsys) -> None:
     cli_main([
         "event", "add", str(input_path),
         "start", "1.0",
-        "-o", str(with_events_path),
     ])
     cli_main([
-        "event", "add", str(with_events_path),
+        "event", "add", str(input_path),
         "collision", "5.0",
-        "-o", str(with_events2_path),
     ])
+
+    # Clear captured output from add commands
+    capsys.readouterr()
 
     # List only "collision" events
     cli_main([
-        "event", "list", str(with_events2_path),
+        "event", "list", str(input_path),
         "--name", "collision",
     ])
 
@@ -277,7 +255,6 @@ def test_cli_event_list_json_output(tmp_path: Path, capsys) -> None:
     import json
 
     input_path = tmp_path / "input.mcap"
-    with_events_path = tmp_path / "with_events.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -286,14 +263,13 @@ def test_cli_event_list_json_output(tmp_path: Path, capsys) -> None:
         "event", "add", str(input_path),
         "test_event", "2.5",
         "--description", "Test description",
-        "-o", str(with_events_path),
     ])
 
     # Clear captured output from the add command
     capsys.readouterr()
 
     cli_main([
-        "event", "list", str(with_events_path),
+        "event", "list", str(input_path),
         "--json",
     ])
 
@@ -309,7 +285,6 @@ def test_cli_event_list_json_output(tmp_path: Path, capsys) -> None:
 def test_cli_event_preserves_messages(tmp_path: Path) -> None:
     """Test that adding events preserves all messages."""
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -319,11 +294,10 @@ def test_cli_event_preserves_messages(tmp_path: Path) -> None:
     cli_main([
         "event", "add", str(input_path),
         "test", "1.5",
-        "-o", str(output_path),
     ])
 
     # Verify all messages are preserved
-    with McapRecordReaderFactory.from_file(output_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         channels = reader.get_channels()
         assert len(channels) == 2
 
@@ -334,7 +308,6 @@ def test_cli_event_preserves_messages(tmp_path: Path) -> None:
 def test_cli_event_preserves_attachments_and_metadata(tmp_path: Path) -> None:
     """Test that adding events preserves attachments and other metadata."""
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
 
     with McapFileWriter.open(input_path, chunk_size=1024) as writer:
         writer.write_message("/foo", int(1e9), Int32(data=1))
@@ -344,10 +317,9 @@ def test_cli_event_preserves_attachments_and_metadata(tmp_path: Path) -> None:
     cli_main([
         "event", "add", str(input_path),
         "test", "1.0",
-        "-o", str(output_path),
     ])
 
-    with McapRecordReaderFactory.from_file(output_path) as reader:
+    with McapRecordReaderFactory.from_file(input_path) as reader:
         attachments = reader.get_attachments()
         assert len(attachments) == 1
         assert attachments[0].name == "test.txt"
@@ -355,53 +327,6 @@ def test_cli_event_preserves_attachments_and_metadata(tmp_path: Path) -> None:
         all_metadata = reader.get_metadata()
         # Should have config + event
         assert len(all_metadata) == 2
-
-
-def test_cli_event_add_overwrite(tmp_path: Path) -> None:
-    """Test overwrite flag for event add."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Create output file
-    output_path.touch()
-
-    # Without overwrite, should fail
-    with pytest.raises(ValueError, match="Output mcap exists"):
-        cli_main([
-            "event", "add", str(input_path),
-            "test", "1.0",
-            "-o", str(output_path),
-        ])
-
-    # With overwrite, should succeed
-    cli_main([
-        "event", "add", str(input_path),
-        "test", "1.0",
-        "-o", str(output_path),
-        "--overwrite",
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-
-
-def test_cli_event_add_same_input_output_error(tmp_path: Path) -> None:
-    """Test that adding event with same input/output path raises error."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    with pytest.raises(ValueError, match="Input path cannot be same as output"):
-        cli_main([
-            "event", "add", str(input_path),
-            "test", "1.0",
-            "-o", str(input_path),
-        ])
 
 
 def test_cli_event_bag_not_supported(tmp_path: Path, capsys) -> None:
@@ -425,3 +350,32 @@ def test_cli_event_bag_not_supported(tmp_path: Path, capsys) -> None:
             "event", "add", str(input_path),
             "test", "1.0",
         ])
+
+
+def test_cli_event_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
+    """Test that deleting events preserves non-event metadata."""
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Int32(data=1))
+        writer.write_metadata("config", {"setting": "value"})
+
+    # Add an event
+    cli_main([
+        "event", "add", str(input_path),
+        "test_event", "1.0",
+    ])
+
+    # Delete all events
+    cli_main([
+        "event", "delete", str(input_path),
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        all_metadata = reader.get_metadata()
+        # Should only have config metadata (event should be deleted)
+        assert len(all_metadata) == 1
+        assert all_metadata[0].name == "config"
+        assert all_metadata[0].metadata["setting"] == "value"

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -1,5 +1,8 @@
 """Tests for the event CLI command."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import pytest
@@ -11,281 +14,90 @@ from pybag.mcap_writer import McapFileWriter
 from pybag.ros2.humble.std_msgs import Int32
 
 
-def test_cli_event_list_empty(tmp_path: Path) -> None:
-    """Test listing events when there are none."""
+def _write_messages(path: Path, topics: tuple[str, ...], start_s: int, end_s: int) -> None:
+    with McapFileWriter.open(path, chunk_size=1024) as writer:
+        for second in range(start_s, end_s + 1):
+            for idx, topic in enumerate(topics):
+                writer.write_message(topic, int(second * 1e9), Int32(data=second * 10 + idx))
+
+
+def test_cli_event_list_empty(tmp_path: Path, capsys) -> None:
     input_path = tmp_path / "input.mcap"
+    _write_messages(input_path, ("/foo",), 0, 2)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # List events (should be empty)
     cli_main(["event", "list", str(input_path)])
 
+    out = capsys.readouterr().out
+    assert "Events (0):" in out
+    assert "No events found." in out
 
-def test_cli_event_add_and_list(tmp_path: Path) -> None:
-    """Test adding an event and listing it."""
+
+def test_cli_event_add_and_list_filters_json(tmp_path: Path, capsys) -> None:
     input_path = tmp_path / "input.mcap"
+    _write_messages(input_path, ("/foo",), 0, 10)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_message("/foo", int(2e9), Int32(data=2))
-
-    # Add an event (modifies file in place)
-    cli_main([
-        "event", "add", str(input_path),
-        "start", "1.5",
-    ])
-
-    # Verify event was added
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-        assert metadata[0].metadata["name"] == "start"
-        assert metadata[0].metadata["timestamp"] == str(int(1.5e9))
-
-        # Verify messages are preserved
-        channels = reader.get_channels()
-        assert len(channels) == 1
-
-
-def test_cli_event_add_with_description(tmp_path: Path) -> None:
-    """Test adding an event with description."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Add event with description
-    cli_main([
-        "event", "add", str(input_path),
-        "collision", "5.0",
-        "--description", "Hit obstacle at corner",
-    ])
-
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-        assert metadata[0].metadata["name"] == "collision"
-        assert metadata[0].metadata["description"] == "Hit obstacle at corner"
-
-
-def test_cli_event_add_with_extra_fields(tmp_path: Path) -> None:
-    """Test adding an event with extra key-value pairs."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Add event with extra fields
-    cli_main([
-        "event", "add", str(input_path),
-        "waypoint", "10.0",
-        "--extra", "waypoint_id=42",
-        "--extra", "location=entrance",
-    ])
-
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-        assert metadata[0].metadata["name"] == "waypoint"
-        assert metadata[0].metadata["waypoint_id"] == "42"
-        assert metadata[0].metadata["location"] == "entrance"
-
-
-def test_cli_event_add_multiple_events(tmp_path: Path) -> None:
-    """Test adding multiple events."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_message("/foo", int(5e9), Int32(data=2))
-        writer.write_message("/foo", int(10e9), Int32(data=3))
-
-    # Add first event
-    cli_main([
-        "event", "add", str(input_path),
-        "start", "0.0",
-    ])
-
-    # Add second event
-    cli_main([
-        "event", "add", str(input_path),
-        "end", "10.0",
-    ])
-
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 2
-        names = [m.metadata["name"] for m in metadata]
-        assert "start" in names
-        assert "end" in names
-
-
-def test_cli_event_add_with_output(tmp_path: Path) -> None:
-    """Test adding an event with -o flag copies MCAP and adds event to copy."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_message("/foo", int(2e9), Int32(data=2))
-
-    # Add event with -o flag (copy mode)
-    cli_main([
-        "event", "add", str(input_path),
-        "test_event", "1.5",
-        "-o", str(output_path),
-    ])
-
-    # Verify original file is unchanged (no events)
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 0
-
-    # Verify output file has the event and messages
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-        assert metadata[0].metadata["name"] == "test_event"
-
-        # Verify messages are copied
-        messages = list(reader.get_messages())
-        assert len(messages) == 2
-
-
-def test_cli_event_soft_delete(tmp_path: Path) -> None:
-    """Test soft delete (default) marks events as deleted."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Add an event
-    cli_main([
-        "event", "add", str(input_path),
-        "event1", "1.0",
-    ])
-
-    # Soft delete (default, no --force)
-    cli_main([
-        "event", "delete", str(input_path),
-        "--name", "event1",
-    ])
-
-    # The event record should still exist but be marked as deleted
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        all_events = reader.get_metadata(name=EVENT_METADATA_NAME)
-        # Original + deleted version
-        assert len(all_events) == 2
-        # The deleted version has deleted=true
-        deleted_events = [e for e in all_events if e.metadata.get("deleted") == "true"]
-        assert len(deleted_events) == 1
-
-
-def test_cli_event_soft_delete_hidden_from_list(tmp_path: Path, capsys) -> None:
-    """Test that soft deleted events are hidden from list by default."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "visible", "1.0",
-    ])
-    cli_main([
-        "event", "add", str(input_path),
-        "to_delete", "2.0",
-    ])
-
-    # Soft delete one event
-    cli_main([
-        "event", "delete", str(input_path),
-        "--name", "to_delete",
-    ])
-
-    capsys.readouterr()
-
-    # List should only show the visible event
-    cli_main(["event", "list", str(input_path)])
-    captured = capsys.readouterr()
-    assert "visible" in captured.out
-    assert "to_delete" not in captured.out
-
-
-def test_cli_event_list_include_deleted(tmp_path: Path, capsys) -> None:
-    """Test that --include-deleted shows soft deleted events."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "event1", "1.0",
-    ])
-
-    # Soft delete
-    cli_main([
-        "event", "delete", str(input_path),
-        "--name", "event1",
-    ])
-
-    capsys.readouterr()
-
-    # List with --include-deleted should show the event
-    cli_main(["event", "list", str(input_path), "--include-deleted"])
-    captured = capsys.readouterr()
-    assert "event1" in captured.out
-
-
-def test_cli_event_hard_delete_all(tmp_path: Path) -> None:
-    """Test hard delete (-o) removes all events from file."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    # Create MCAP with messages
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Add an event
-    cli_main([
-        "event", "add", str(input_path),
-        "event1", "1.0",
-    ])
-
-    # Hard delete all events (using -o triggers hard delete)
-    cli_main([
-        "event", "delete", str(input_path),
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 0
-
-
-def test_cli_event_hard_delete_by_name(tmp_path: Path) -> None:
-    """Test hard deleting events by name."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    # Add first event
     cli_main([
         "event", "add", str(input_path),
         "start", "1.0",
+        "--description", "start marker",
+        "--extra", "source=operator",
     ])
-
-    # Add second event
     cli_main([
         "event", "add", str(input_path),
         "collision", "5.0",
     ])
 
-    # Hard delete only "collision" events (using -o triggers hard delete)
+    capsys.readouterr()
+    cli_main([
+        "event", "list", str(input_path),
+        "--name", "start",
+        "--start-time", "0.5",
+        "--end-time", "2.0",
+        "--json",
+    ])
+
+    events = json.loads(capsys.readouterr().out)
+    assert len(events) == 1
+    assert events[0]["name"] == "start"
+    assert events[0]["timestamp"] == int(1e9)
+    assert events[0]["description"] == "start marker"
+    assert events[0]["source"] == "operator"
+
+
+def test_cli_event_add_with_output_copies_file(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 2)
+
+    cli_main([
+        "event", "add", str(input_path),
+        "incident", "1.0",
+        "-o", str(output_path),
+    ])
+
+    with McapRecordReaderFactory.from_file(input_path) as reader:
+        assert len(reader.get_metadata(name=EVENT_METADATA_NAME)) == 0
+
+    with McapRecordReaderFactory.from_file(output_path) as reader:
+        events = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert len(events) == 1
+        assert events[0].metadata["name"] == "incident"
+        assert len(list(reader.get_messages())) == 3
+
+
+def test_cli_event_delete_by_name_preserves_other_data(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.mcap"
+    output_path = tmp_path / "output.mcap"
+
+    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
+        for second in range(3):
+            writer.write_message("/foo", int(second * 1e9), Int32(data=second))
+        writer.write_attachment("note.txt", b"hello", "text/plain")
+        writer.write_metadata("config", {"mode": "test"})
+
+    cli_main(["event", "add", str(input_path), "start", "0.0"])
+    cli_main(["event", "add", str(input_path), "collision", "2.0"])
+
     cli_main([
         "event", "delete", str(input_path),
         "--name", "collision",
@@ -293,34 +105,26 @@ def test_cli_event_hard_delete_by_name(tmp_path: Path) -> None:
     ])
 
     with McapRecordReaderFactory.from_file(output_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 1
-        assert metadata[0].metadata["name"] == "start"
+        events = reader.get_metadata(name=EVENT_METADATA_NAME)
+        assert [event.metadata["name"] for event in events] == ["start"]
+        assert len(list(reader.get_messages())) == 3
+        assert len(reader.get_attachments()) == 1
+
+        all_metadata = reader.get_metadata()
+        config = [m for m in all_metadata if m.name == "config"]
+        assert len(config) == 1
+        assert config[0].metadata["mode"] == "test"
 
 
-def test_cli_event_hard_delete_by_time_range(tmp_path: Path) -> None:
-    """Test hard deleting events by time range."""
+def test_cli_event_delete_by_time_range(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 10)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
+    cli_main(["event", "add", str(input_path), "early", "1.0"])
+    cli_main(["event", "add", str(input_path), "mid", "5.0"])
+    cli_main(["event", "add", str(input_path), "late", "9.0"])
 
-    # Add events at different times
-    cli_main([
-        "event", "add", str(input_path),
-        "event1", "1.0",
-    ])
-    cli_main([
-        "event", "add", str(input_path),
-        "event2", "5.0",
-    ])
-    cli_main([
-        "event", "add", str(input_path),
-        "event3", "10.0",
-    ])
-
-    # Hard delete events between 4s and 6s (using -o triggers hard delete)
     cli_main([
         "event", "delete", str(input_path),
         "--start-time", "4.0",
@@ -329,295 +133,74 @@ def test_cli_event_hard_delete_by_time_range(tmp_path: Path) -> None:
     ])
 
     with McapRecordReaderFactory.from_file(output_path) as reader:
-        metadata = reader.get_metadata(name=EVENT_METADATA_NAME)
-        assert len(metadata) == 2
-        names = [m.metadata["name"] for m in metadata]
-        assert "event1" in names
-        assert "event3" in names
-        assert "event2" not in names
+        names = [m.metadata["name"] for m in reader.get_metadata(name=EVENT_METADATA_NAME)]
+        assert names == ["early", "late"]
 
 
-def test_cli_event_list_filter_by_name(tmp_path: Path, capsys) -> None:
-    """Test listing events filtered by name."""
+def test_cli_event_delete_requires_output(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
+    _write_messages(input_path, ("/foo",), 0, 1)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "start", "1.0",
-    ])
-    cli_main([
-        "event", "add", str(input_path),
-        "collision", "5.0",
-    ])
-
-    # Clear captured output from add commands
-    capsys.readouterr()
-
-    # List only "collision" events
-    cli_main([
-        "event", "list", str(input_path),
-        "--name", "collision",
-    ])
-
-    captured = capsys.readouterr()
-    assert "collision" in captured.out
-    assert "start" not in captured.out or "start" in captured.out.split("collision")[0]  # Should not be in data rows
+    with pytest.raises(SystemExit):
+        cli_main(["event", "delete", str(input_path)])
 
 
-def test_cli_event_list_json_output(tmp_path: Path, capsys) -> None:
-    """Test listing events in JSON format."""
-    import json
-
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "test_event", "2.5",
-        "--description", "Test description",
-    ])
-
-    # Clear captured output from the add command
-    capsys.readouterr()
-
-    cli_main([
-        "event", "list", str(input_path),
-        "--json",
-    ])
-
-    captured = capsys.readouterr()
-    # The JSON output should be the entire output when --json is used
-    events = json.loads(captured.out.strip())
-    assert len(events) == 1
-    assert events[0]["name"] == "test_event"
-    assert events[0]["timestamp"] == int(2.5e9)
-    assert events[0]["description"] == "Test description"
-
-
-def test_cli_event_preserves_messages(tmp_path: Path) -> None:
-    """Test that adding events preserves all messages."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_message("/bar", int(2e9), Int32(data=2))
-        writer.write_message("/foo", int(3e9), Int32(data=3))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "test", "1.5",
-    ])
-
-    # Verify all messages are preserved
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        channels = reader.get_channels()
-        assert len(channels) == 2
-
-        messages = list(reader.get_messages())
-        assert len(messages) == 3
-
-
-def test_cli_event_preserves_attachments_and_metadata(tmp_path: Path) -> None:
-    """Test that adding events preserves attachments and other metadata."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_attachment("test.txt", b"test data", "text/plain")
-        writer.write_metadata("config", {"key": "value"})
-
-    cli_main([
-        "event", "add", str(input_path),
-        "test", "1.0",
-    ])
-
-    with McapRecordReaderFactory.from_file(input_path) as reader:
-        attachments = reader.get_attachments()
-        assert len(attachments) == 1
-        assert attachments[0].name == "test.txt"
-
-        all_metadata = reader.get_metadata()
-        # Should have config + event
-        assert len(all_metadata) == 2
-
-
-def test_cli_event_bag_not_supported(tmp_path: Path, capsys) -> None:
-    """Test that events are not supported for bag files."""
-    from pybag.bag_writer import BagFileWriter
-    from pybag.ros1.noetic.std_msgs import Int32 as Ros1Int32
-
-    input_path = tmp_path / "input.bag"
-
-    with BagFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Ros1Int32(data=1))
-
-    # List should print message about not supported
-    cli_main(["event", "list", str(input_path)])
-    captured = capsys.readouterr()
-    assert "not supported" in captured.out.lower()
-
-    # Add should raise error
-    with pytest.raises(ValueError, match="not supported in bag"):
-        cli_main([
-            "event", "add", str(input_path),
-            "test", "1.0",
-        ])
-
-
-def test_cli_event_hard_delete_preserves_non_event_metadata(tmp_path: Path) -> None:
-    """Test that hard deleting events preserves non-event metadata."""
+def test_cli_event_clip_before_after_with_topic_filter(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo", "/bar"), 0, 10)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-        writer.write_metadata("config", {"setting": "value"})
+    cli_main(["event", "add", str(input_path), "incident", "5.0"])
 
-    # Add an event
-    cli_main([
-        "event", "add", str(input_path),
-        "test_event", "1.0",
-    ])
-
-    # Hard delete all events (using -o triggers hard delete)
-    cli_main([
-        "event", "delete", str(input_path),
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        all_metadata = reader.get_metadata()
-        # Should only have config metadata (event should be deleted)
-        assert len(all_metadata) == 1
-        assert all_metadata[0].name == "config"
-        assert all_metadata[0].metadata["setting"] == "value"
-
-
-#####################
-# Clip Command Tests
-#####################
-
-def test_cli_event_clip_basic(tmp_path: Path) -> None:
-    """Test basic clip around an event."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    # Create MCAP with messages spread over time
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            # Messages at 0s, 1s, 2s, ..., 19s
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-
-    # Add an event at 10s
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # Clip around the event with 3s before and after
-    cli_main([
-        "event", "clip", str(input_path),
-        "incident",
-        "--before", "3",
-        "--after", "3",
-        "-o", str(output_path),
-    ])
-
-    # Verify clipped file contains messages from 7s to 13s
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
-
-        # Should have messages at 7, 8, 9, 10, 11, 12, 13 = 7 messages
-        assert len(messages) == 7
-        assert min(timestamps) >= 7.0
-        assert max(timestamps) <= 13.0
-
-
-def test_cli_event_clip_before_only(tmp_path: Path) -> None:
-    """Test that --before clips from (event_time - before) to event_time."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # Only specify --before, should clip from 8s to 10s
     cli_main([
         "event", "clip", str(input_path),
         "incident",
         "--before", "2",
+        "--after", "1",
+        "--include-topic", "/foo",
         "-o", str(output_path),
     ])
 
     with McapRecordReaderFactory.from_file(output_path) as reader:
         messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
+        seconds = [m.log_time / 1e9 for m in messages]
 
-        # Should have messages at 8, 9, 10 = 3 messages
-        assert len(messages) == 3
-        assert min(timestamps) >= 8.0
-        assert max(timestamps) <= 10.0
+        assert len(messages) == 4
+        assert min(seconds) >= 3.0
+        assert max(seconds) <= 6.0
+
+        topics = {reader.get_channels()[m.channel_id].topic for m in messages}
+        assert topics == {"/foo"}
 
 
-def test_cli_event_clip_after_only(tmp_path: Path) -> None:
-    """Test that --after clips from event_time to (event_time + after)."""
+def test_cli_event_clip_default_uses_event_timestamp_only(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 10)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+    cli_main(["event", "add", str(input_path), "incident", "5.0"])
 
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # Only specify --after, should clip from 10s to 12s
     cli_main([
         "event", "clip", str(input_path),
         "incident",
-        "--after", "2",
         "-o", str(output_path),
     ])
 
     with McapRecordReaderFactory.from_file(output_path) as reader:
         messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
+        seconds = [m.log_time / 1e9 for m in messages]
 
-        # Should have messages at 10, 11, 12 = 3 messages
-        assert len(messages) == 3
-        assert min(timestamps) >= 10.0
-        assert max(timestamps) <= 12.0
+        assert len(messages) == 1
+        assert seconds == [5.0]
 
 
-def test_cli_event_clip_margin(tmp_path: Path) -> None:
-    """Test that --margin clips symmetrically before and after."""
+def test_cli_event_clip_margin_is_symmetric(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
     output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 10)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+    cli_main(["event", "add", str(input_path), "incident", "5.0"])
 
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # Specify --margin for symmetric clipping
     cli_main([
         "event", "clip", str(input_path),
         "incident",
@@ -626,204 +209,42 @@ def test_cli_event_clip_margin(tmp_path: Path) -> None:
     ])
 
     with McapRecordReaderFactory.from_file(output_path) as reader:
-        messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
-
-        # Should have messages at 8, 9, 10, 11, 12 = 5 messages
-        assert len(messages) == 5
-        assert min(timestamps) >= 8.0
-        assert max(timestamps) <= 12.0
+        seconds = [m.log_time / 1e9 for m in reader.get_messages()]
+        assert min(seconds) >= 3.0
+        assert max(seconds) <= 7.0
+        assert len(seconds) == 5
 
 
-def test_cli_event_clip_default_margin(tmp_path: Path) -> None:
-    """Test that clip uses default 5s margin when no --before/--after given."""
+def test_cli_event_clip_margin_conflicts_with_before_after(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 5)
+    cli_main(["event", "add", str(input_path), "incident", "2.0"])
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # No margin specified, should default to 5s before and after
-    cli_main([
-        "event", "clip", str(input_path),
-        "incident",
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
-
-        # Should have messages at 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 = 11 messages
-        assert len(messages) == 11
-        assert min(timestamps) >= 5.0
-        assert max(timestamps) <= 15.0
-
-
-def test_cli_event_clip_asymmetric(tmp_path: Path) -> None:
-    """Test clip with different before and after values."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(20):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "10.0",
-    ])
-
-    # 2s before, 5s after
-    cli_main([
-        "event", "clip", str(input_path),
-        "incident",
-        "--before", "2",
-        "--after", "5",
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        messages = list(reader.get_messages())
-        timestamps = [m.log_time / 1e9 for m in messages]
-
-        # Should have messages at 8, 9, 10, 11, 12, 13, 14, 15 = 8 messages
-        assert len(messages) == 8
-        assert min(timestamps) >= 8.0
-        assert max(timestamps) <= 15.0
-
-
-def test_cli_event_clip_event_not_found(tmp_path: Path) -> None:
-    """Test that clip raises error when event not found."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    with pytest.raises(ValueError, match="No event found"):
-        cli_main([
-            "event", "clip", str(input_path),
-            "nonexistent",
-        ])
-
-
-def test_cli_event_clip_margin_with_before_error(tmp_path: Path) -> None:
-    """Test that --margin cannot be used with --before."""
-    input_path = tmp_path / "input.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        writer.write_message("/foo", int(1e9), Int32(data=1))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "1.0",
-    ])
-
-    with pytest.raises(ValueError, match="Cannot use --margin together with"):
+    with pytest.raises(ValueError, match="Cannot use --margin together"):
         cli_main([
             "event", "clip", str(input_path),
             "incident",
-            "--margin", "5",
-            "--before", "2",
+            "--margin", "2",
+            "--before", "1",
         ])
 
 
-def test_cli_event_clip_with_topic_filter(tmp_path: Path) -> None:
-    """Test clip with topic filtering."""
+def test_cli_event_clip_event_not_found(tmp_path: Path) -> None:
     input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
+    _write_messages(input_path, ("/foo",), 0, 3)
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(10):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-            writer.write_message("/bar", int(i * 1e9), Int32(data=i * 10))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "5.0",
-    ])
-
-    # Clip but only include /foo topic
-    cli_main([
-        "event", "clip", str(input_path),
-        "incident",
-        "--before", "2",
-        "--after", "2",
-        "--include-topic", "/foo",
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        channels = reader.get_channels()
-        # Should only have /foo channel
-        assert len(channels) == 1
-        topic_names = [ch.topic for ch in channels.values()]
-        assert "/foo" in topic_names
-        assert "/bar" not in topic_names
+    with pytest.raises(ValueError, match="No event found"):
+        cli_main(["event", "clip", str(input_path), "missing"])
 
 
-def test_cli_event_clip_default_output_name(tmp_path: Path) -> None:
-    """Test that clip generates appropriate default output filename."""
-    input_path = tmp_path / "recording.mcap"
+def test_cli_event_bag_not_supported(tmp_path: Path) -> None:
+    from pybag.bag_writer import BagFileWriter
+    from pybag.ros1.noetic.std_msgs import Int32 as Ros1Int32
 
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(10):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
+    input_path = tmp_path / "input.bag"
 
-    cli_main([
-        "event", "add", str(input_path),
-        "collision", "5.0",
-    ])
+    with BagFileWriter.open(input_path, chunk_size=1024) as writer:
+        writer.write_message("/foo", int(1e9), Ros1Int32(data=1))
 
-    # Don't specify output path
-    cli_main([
-        "event", "clip", str(input_path),
-        "collision",
-        "--before", "2",
-        "--after", "2",
-    ])
-
-    # Check that default output file was created
-    expected_output = tmp_path / "recording_clip_collision.mcap"
-    assert expected_output.exists()
-
-
-def test_cli_event_clip_preserves_metadata(tmp_path: Path) -> None:
-    """Test that clip preserves metadata and attachments within time range."""
-    input_path = tmp_path / "input.mcap"
-    output_path = tmp_path / "output.mcap"
-
-    with McapFileWriter.open(input_path, chunk_size=1024) as writer:
-        for i in range(10):
-            writer.write_message("/foo", int(i * 1e9), Int32(data=i))
-        writer.write_metadata("config", {"key": "value"})
-        # Attachment at 5s (within clip range of 3s-7s)
-        writer.write_attachment("test.txt", b"test data", "text/plain", log_time=int(5e9))
-
-    cli_main([
-        "event", "add", str(input_path),
-        "incident", "5.0",
-    ])
-
-    cli_main([
-        "event", "clip", str(input_path),
-        "incident",
-        "--before", "2",
-        "--after", "2",
-        "-o", str(output_path),
-    ])
-
-    with McapRecordReaderFactory.from_file(output_path) as reader:
-        all_metadata = reader.get_metadata()
-        # Should have config + event metadata
-        assert len(all_metadata) == 2
-
-        attachments = reader.get_attachments()
-        assert len(attachments) == 1
-        assert attachments[0].name == "test.txt"
+    with pytest.raises(ValueError, match="not supported in bag"):
+        cli_main(["event", "list", str(input_path)])


### PR DESCRIPTION
Events allow users to mark significant occurrences in MCAP recordings,
such as collisions, waypoints, or other notable moments. Events are
stored as metadata records with a special name prefix (pybag.event).

New CLI subcommands:
- pybag event list <file> - List events with optional filtering by name/time
- pybag event add <file> <name> <timestamp> - Add new events with optional
  description and custom key-value pairs
- pybag event delete <file> - Delete events with optional filtering

Features:
- Events support timestamps, names, descriptions, and custom fields
- JSON output format supported for list command
- Time range filtering for list and delete operations
- Preserves all existing messages, attachments, and metadata
- Events are only supported for MCAP format (not bag files)